### PR TITLE
Add samconfig argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ cd cloud-cost-saver
 To analyze a CloudFormation template, use the following command:
 
 ```sh
-cargo run -- aws --template src/sample-cfn.yaml --config .cloudsaving.yaml
+cargo run -- aws --template src/fixtures/aws/cfn-testing.yaml --environment default --samconfig src/fixtures/aws/samconfig.toml --config .cloudsaving.yaml
 ```
+
 ## Example Output
 
 When you run the analysis, you might see output similar to the following:

--- a/src/parsers/cfn.rs
+++ b/src/parsers/cfn.rs
@@ -307,6 +307,7 @@ pub(crate) fn parse_samconfig(file_path: &str) -> Result<SamConfig, Box<dyn std:
 }
 
 mod test {
+    #[allow(unused_imports)]
     use super::*;
 
     #[test]


### PR DESCRIPTION
This pull request includes several changes to the `cloud-cost-saver` project to add support for parsing `samconfig` files and handling environment variables. The most important changes include updates to the `README.md`, modifications to the `main.rs` file to incorporate new arguments and logic, and the addition of a new function in `cfn.rs`.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R30): Updated the example command to include `--environment` and `--samconfig` options.

### Code updates:
* `src/main.rs`: 
  - Added new arguments `environment` and `samconfig` to the `Args` struct.
  - Updated the `main` function to parse and use the `samconfig` file and environment variable.
  - Imported the new `parse_samconfig` function from `parsers::cfn` module.

* [`src/parsers/cfn.rs`](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20R310): Added a new function `parse_samconfig` to parse the `samconfig` file.