### PR TITLE
Feature/findinmap

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -129,10 +129,10 @@ mod tests_cfn {
             for rule in default_rule_config.rules.values_mut() {
                 rule.enabled = false;
             }
-            let config = Config {
+            
+            Config {
                 cloudformation: Some(default_rule_config),
-            };
-            config
+            }
         }
 
         fn get_error_reporter<'a>(path: &str) -> ErrorReporter {
@@ -187,7 +187,7 @@ mod tests_cfn {
                 }
             }
 
-            fn create_checker<'a>(&'a mut self) -> Checker<'a, YamlLineMarker> {
+            fn create_checker(&mut self) -> Checker<'_, YamlLineMarker> {
                 Checker::new(
                     &self.config,
                     &mut self.error_reporter,

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -135,11 +135,11 @@ mod tests_cfn {
             }
         }
 
-        fn get_error_reporter<'a>(path: &str) -> ErrorReporter {
+        fn get_error_reporter(path: &str) -> ErrorReporter {
             ErrorReporter::new(&format!("src/fixtures/aws/{}", path))
         }
 
-        fn get_cloudformation<'a>(path: &str) -> CloudFormation {
+        fn get_cloudformation(path: &str) -> CloudFormation {
             parse_cloudformation(&format!("src/fixtures/aws/{}", path)).unwrap()
         }
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -129,7 +129,7 @@ mod tests_cfn {
             for rule in default_rule_config.rules.values_mut() {
                 rule.enabled = false;
             }
-            
+
             Config {
                 cloudformation: Some(default_rule_config),
             }

--- a/src/fixtures/aws/cfn-parsing-test.yaml
+++ b/src/fixtures/aws/cfn-parsing-test.yaml
@@ -15,14 +15,6 @@ Parameters:
     Type: String
     Default: "INFO"
 
-Mappings:
-  Environments:
-    default:
-      Name: "Value"
-    prod:
-      Name: "Value"
-
-
 Globals:
   Function:
     Timeout: 60
@@ -32,6 +24,14 @@ Globals:
         POWERTOOLS_SERVICE_NAME: !Join [ '-', [ !Ref AWS::StackName, 'xray' ] ]
         REGION_NAME: !Ref AWS::Region
         ENVIRONMENT: !Ref Environment
+        POWERTOOLS_LOGGER_SAMPLE_RATE: !FindInMap [ "Environments", !Ref Environment, "PowerToolsLoggerSampleRate" ]
+
+Mappings:
+  Environments:
+    default:
+      PowerToolsLoggerSampleRate: 1
+    prod:
+      PowerToolsLoggerSampleRate: 0.01
 
 Resources:
   ExampleResource:

--- a/src/parsers/cfn.rs
+++ b/src/parsers/cfn.rs
@@ -83,7 +83,8 @@ impl CloudFormation {
                                             if let Some(map_sequence) =
                                                 tagged_value.value.as_sequence()
                                             {
-                                                let map_name = map_sequence.first()
+                                                let map_name = map_sequence
+                                                    .first()
                                                     .and_then(|v| v.as_str())
                                                     .expect("Map name not found");
                                                 let top_level_key = map_sequence.get(1);
@@ -98,21 +99,20 @@ impl CloudFormation {
                                                 ) = top_level_key
                                                 {
                                                     if ref_tagged_value.tag == "!Ref" {
-                                                        if let Some(ref_value) =
-                                                            ref_tagged_value.value.as_str()
-                                                        {
-                                                            self.parameters
-                                                                .as_ref()
-                                                                .and_then(|p| p.get(ref_value))
-                                                                .and_then(|parameter| {
-                                                                    parameter.default.as_ref()
-                                                                }).cloned()
-                                                                .unwrap_or_else(|| {
-                                                                    top_level_key.unwrap().clone()
-                                                                })
-                                                        } else {
-                                                            top_level_key.unwrap().clone()
-                                                        }
+                                                        ref_tagged_value
+                                                            .value
+                                                            .as_str()
+                                                            .and_then(|ref_value| {
+                                                                self.parameters
+                                                                    .as_ref()
+                                                                    .and_then(|p| p.get(ref_value))
+                                                                    .and_then(|parameter| {
+                                                                        parameter.default.clone()
+                                                                    })
+                                                            })
+                                                            .unwrap_or_else(|| {
+                                                                top_level_key.unwrap().clone()
+                                                            })
                                                     } else {
                                                         top_level_key.unwrap().clone()
                                                     }
@@ -144,7 +144,6 @@ impl CloudFormation {
             }
         }
     }
-
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -431,9 +430,7 @@ mod test {
         assert_eq!(samconfig.version, Some("0.1".to_string()));
         assert_eq!(samconfig.environments.len(), 2);
         let default_env = samconfig.environments.get("default").unwrap();
-        assert!(
-            default_env.deploy.as_ref().unwrap().parameters.is_some()
-        );
+        assert!(default_env.deploy.as_ref().unwrap().parameters.is_some());
         let deploy_params = default_env
             .deploy
             .as_ref()

--- a/src/parsers/cfn.rs
+++ b/src/parsers/cfn.rs
@@ -63,18 +63,80 @@ impl CloudFormation {
                         {
                             for (_, v) in function_environment_variables_map.iter_mut() {
                                 if let serde_yaml::Value::Tagged(tagged_value) = v {
-                                    if tagged_value.tag.to_string().as_str() == "!Ref" {
-                                        if let Some(ref_value) = tagged_value.value.as_str() {
-                                            if let Some(parameter) = self
-                                                .parameters
-                                                .as_ref()
-                                                .and_then(|p| p.get(ref_value))
-                                            {
-                                                if let Some(default) = parameter.default.as_ref() {
-                                                    *v = default.clone();
+                                    match tagged_value.tag.to_string().as_str() {
+                                        "!Ref" => {
+                                            if let Some(ref_value) = tagged_value.value.as_str() {
+                                                if let Some(parameter) = self
+                                                    .parameters
+                                                    .as_ref()
+                                                    .and_then(|p| p.get(ref_value))
+                                                {
+                                                    if let Some(default) =
+                                                        parameter.default.as_ref()
+                                                    {
+                                                        *v = default.clone();
+                                                    }
                                                 }
                                             }
                                         }
+                                        "!FindInMap" => {
+                                            if let Some(map_sequence) =
+                                                tagged_value.value.as_sequence()
+                                            {
+                                                let map_name = map_sequence
+                                                    .get(0)
+                                                    .and_then(|v| v.as_str())
+                                                    .expect("Map name not found");
+                                                let top_level_key = map_sequence.get(1);
+                                                let second_level_key = map_sequence
+                                                    .get(2)
+                                                    .and_then(|v| v.as_str())
+                                                    .expect("Second level key not found");
+
+                                                // Handle nested !Ref in top_level_key
+                                                let top_level_key = if let Some(
+                                                    serde_yaml::Value::Tagged(ref_tagged_value),
+                                                ) = top_level_key
+                                                {
+                                                    if ref_tagged_value.tag == "!Ref" {
+                                                        if let Some(ref_value) =
+                                                            ref_tagged_value.value.as_str()
+                                                        {
+                                                            self.parameters
+                                                                .as_ref()
+                                                                .and_then(|p| p.get(ref_value))
+                                                                .and_then(|parameter| {
+                                                                    parameter.default.as_ref()
+                                                                })
+                                                                .map(|default| default.clone())
+                                                                .unwrap_or_else(|| {
+                                                                    top_level_key.unwrap().clone()
+                                                                })
+                                                        } else {
+                                                            top_level_key.unwrap().clone()
+                                                        }
+                                                    } else {
+                                                        top_level_key.unwrap().clone()
+                                                    }
+                                                } else {
+                                                    top_level_key.unwrap().clone()
+                                                };
+
+                                                if let Some(find_map) = self
+                                                    .mappings
+                                                    .as_ref()
+                                                    .and_then(|m| m.get(map_name))
+                                                {
+                                                    if let Some(taget_value) = find_map.get_value(
+                                                        top_level_key.as_str().unwrap(),
+                                                        second_level_key,
+                                                    ) {
+                                                        *v = taget_value.clone();
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        _ => {}
                                     }
                                 }
                             }
@@ -83,6 +145,17 @@ impl CloudFormation {
                 }
             }
         }
+    }
+
+    fn handle_ref(&self, tagged_value: &serde_yaml::Value) -> Option<serde_yaml::Value> {
+        if let Some(ref_value) = tagged_value.as_str() {
+            if let Some(parameter) = self.parameters.as_ref().and_then(|p| p.get(ref_value)) {
+                if let Some(default) = parameter.default.as_ref() {
+                    return Some(default.clone());
+                }
+            }
+        }
+        None
     }
 }
 
@@ -117,11 +190,11 @@ impl IaCParameter for Parameter {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Mapping {
     #[serde(flatten)]
-    map: HashMap<String, HashMap<String, String>>,
+    map: HashMap<String, HashMap<String, serde_yaml::Value>>,
 }
 
 impl IaCMapping for Mapping {
-    fn get_value(&self, key1: &str, key2: &str) -> Option<String> {
+    fn get_value(&self, key1: &str, key2: &str) -> Option<serde_yaml::Value> {
         self.map.get(key1).and_then(|v| v.get(key2).cloned())
     }
 }
@@ -358,6 +431,10 @@ mod test {
             environment,
             &serde_yaml::Value::String("default".to_string())
         );
+        let powertools_logger_sample_rate = function_environment_variables
+            .get("POWERTOOLS_LOGGER_SAMPLE_RATE")
+            .unwrap();
+        assert_eq!(powertools_logger_sample_rate, &serde_yaml::Value::from(1));
     }
 
     #[test]

--- a/src/parsers/config.rs
+++ b/src/parsers/config.rs
@@ -199,7 +199,7 @@ mod tests {
             .rules
             .get(&RuleType::LambdaArchitectureARM)
             .unwrap();
-        assert_eq!(lambda_architecture_arm.enabled, true);
+        assert!(lambda_architecture_arm.enabled);
 
         let lambda_missing_tag = cloudformation
             .rules

--- a/src/parsers/iac.rs
+++ b/src/parsers/iac.rs
@@ -15,7 +15,7 @@ pub trait IaCParameter {
 
 #[allow(unused)]
 pub trait IaCMapping {
-    fn get_value(&self, key1: &str, key2: &str) -> Option<String>;
+    fn get_value(&self, key1: &str, key2: &str) -> Option<serde_yaml::Value>;
 }
 
 #[allow(unused)]


### PR DESCRIPTION
This pull request includes several changes to improve the handling of CloudFormation mappings and parameters, as well as some code cleanup and refactoring in the `src` directory. The most important changes include adding support for `!FindInMap` tags, modifying the `IaCMapping` trait, and cleaning up the test files.

### Improvements to CloudFormation mappings and parameters:

* [`src/parsers/cfn.rs`](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L66-R138): Added support for handling `!FindInMap` tags in the `function_environment_variables_map` and updated the `Mapping` struct to use `serde_yaml::Value` for nested values. [[1]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L66-R138) [[2]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L120-R184)
* [`src/fixtures/aws/cfn-parsing-test.yaml`](diffhunk://#diff-acfe7202d36dfb2f5fc9018242396b79d98cd8d86bc6c5ee6dc817d32a9f760eL18-L25): Added `Mappings` section for `Environments` with `PowerToolsLoggerSampleRate` values and updated the `Globals` section accordingly. [[1]](diffhunk://#diff-acfe7202d36dfb2f5fc9018242396b79d98cd8d86bc6c5ee6dc817d32a9f760eL18-L25) [[2]](diffhunk://#diff-acfe7202d36dfb2f5fc9018242396b79d98cd8d86bc6c5ee6dc817d32a9f760eR27-R34)

### Code cleanup and refactoring:

* [`src/checker.rs`](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL132-R142): Removed unnecessary lifetimes from function signatures in the `tests_cfn` module. [[1]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL132-R142) [[2]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL190-R190)
* [`src/parsers/cfn.rs`](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20R421-R424): Simplified assertions in test cases and added a new assertion for `POWERTOOLS_LOGGER_SAMPLE_RATE`. [[1]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20R421-R424) [[2]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L369-R433)
* [`src/parsers/config.rs`](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cL202-R202): Simplified assertion for `lambda_architecture_arm.enabled` in the test module.
* [`src/parsers/iac.rs`](diffhunk://#diff-b7e69043a1612251340500c5f7ae5cd45918b8b3bd0c113b44caeb35475c2d1dL18-R18): Modified the `IaCMapping` trait to return `serde_yaml::Value` instead of `String` for `get_value` method.