### PR TITLE
Add CW check for log group class

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,27 @@ In this output:
 - The text following the resource name is the issue description.
 - `src/fixtures/aws/cfn-testing.yaml:20` is the file path and line number where the issue was found.
 
-## Contributing
+## Violations
 
-Contributions are welcome! Please open an issue or submit a pull request on GitHub.
+### AWS CloudFormation
+
+This section lists the various violations that this tool can detect in AWS CloudFormation templates. Each violation is identified by an error code and includes a description of the issue and whether it is enabled by default.
+
+#### Lambda
+| Error Code | Description | Default enabled |
+|------------|-------------|-----------------|
+| LAMBDA-001 | Lambda function creates a log group automatically when invoked for the first time with no expiry Please explicitly create a log group with a retention policy.| true |
+| LAMBDA-002 | Consider using ARM architecture. Lambda functions on ARM can be up to 20% cheaper than equivalent x86 functions. | false |
+| LAMBDA-003 | The Lambda function is missing a tag. Tags are useful for budgeting and identifying areas for cost optimization. | false |
+
+#### CloudWatch
+
+| Error Code | Description | Default enabled |
+|------------|-------------|-----------------|
+| CW-001 | The log group retention period is too long. Consider reducing it to save costs and improve log management efficiency. | false |
+| CW-002 | The log group has no retention policy. Consider setting a retention policy to save costs and improve log management efficiency. | true |
+| CW-003 | The log group is using STANDARD class. Consider using INFREQUENT_ACCESS to save costs. | false |
+
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request on GitHub.

--- a/src/error_reporter.rs
+++ b/src/error_reporter.rs
@@ -47,7 +47,6 @@ impl ErrorReporter {
     pub fn render_errors(&self) -> String {
         self.errors
             .iter()
-            .rev()
             .map(|e| {
                 let span_info = if let Some(span) = &e.span {
                     if let Some(start) = span.start() {

--- a/src/fixtures/aws/cfn-testing.yaml
+++ b/src/fixtures/aws/cfn-testing.yaml
@@ -2,10 +2,16 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: "Example CloudFormation Template"
 
 Resources:
-  MyLogGroupp:
+  MyLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 30
+
+  MyLogGroup2:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: MyLogGroup2
+      LogGroupClass: STANDARD
 
   MyLambdaFunction:
     Type: "AWS::Lambda::Function"

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,9 +42,12 @@ fn main() -> ExitCode {
     if cloud_provider.as_str() == "aws" {
         let mut parsed_cfn =
             parse_cloudformation(&template_file).expect("Failed to parse CloudFormation template");
-        let samconfig = parse_samconfig(args.samconfig.as_deref().expect("samconfig is required"))
-            .expect("Failed to parse samconfig");
-        parsed_cfn.resolve_parameters(&samconfig, &environment);
+        if let Some(samconfig) = args.samconfig.as_deref() {
+            let samconfig = parse_samconfig(samconfig).expect("Failed to parse samconfig");
+            parsed_cfn.resolve_parameters(Some(&samconfig), &environment);
+        } else {
+            parsed_cfn.resolve_parameters(None, &environment);
+        }
         let infra_template = InfratructureTemplate {
             cloudformation: Some(parsed_cfn),
         };

--- a/src/rules/violations.rs
+++ b/src/rules/violations.rs
@@ -40,7 +40,7 @@ impl Violation for LambdaViolation {
     }
 }
 
-#[derive(EnumIter, Debug, Display)]
+#[derive(EnumIter, Debug, Display, PartialEq)]
 pub enum CloudWatchViolation {
     LogRetentionTooLong,
     NoLogRetention,


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and documentation of the AWS CloudFormation template checker. The most important changes include the addition of new violation checks, updates to test cases, and improvements to the documentation.

### New Violation Checks:
* Added a new check for CloudWatch log group class to ensure it is not using the `STANDARD` class, which can be more expensive. (`src/checker.rs`, `src/rules/aws/cloudwatch.rs`) [[1]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faR63-R70) [[2]](diffhunk://#diff-13e28caeadb499fcd8235e6c822e6843cf8e78a90833ef7846e134f6d5d7671aR57-R92)

### Updates to Test Cases:
* Updated test cases to include new violations and ensure accurate testing of the new CloudWatch log group class check. (`src/checker.rs`) [[1]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL240-R249) [[2]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL253-R267) [[3]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faR278-R309)

### Documentation Improvements:
* Added a new section in the `README.md` file to list various violations that the tool can detect in AWS CloudFormation templates, including descriptions and default enabled status. (`README.md`)

### Code Enhancements:
* Modified the `resolve_parameters` method in `CloudFormation` to accept an optional `samconfig` parameter, improving flexibility in parameter resolution. (`src/main.rs`, `src/parsers/cfn.rs`) [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL45-R50) [[2]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L26-R27) [[3]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L52-R53) [[4]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L397-R398)

### Bug Fixes:
* Corrected a typo in the `cfn-testing.yaml` fixture file to ensure the log group name is accurate. (`src/fixtures/aws/cfn-testing.yaml`)