### PR TITLE
Conform configurations to error codes

### DIFF
--- a/.cloudsaving.yaml
+++ b/.cloudsaving.yaml
@@ -1,16 +1,18 @@
 cloudformation:
   rules:
-    LambdaMissingLogGroup:
+    LAMBDA_001:
       enabled: true
-    LambdaArchitectureARM:
+    LAMBDA_002:
       enabled: true
-    LambdaMissingTag:
+    LAMBDA_003:
       enabled: true
-      tags:
+      values:
         - tag1
         - tag2
-    CWLogRetentionPolicy:
+    CW_001:
       enabled: true
       threshold: 14
-    CWInfrequentAccessLogGroupClass:
+    CW_002:
+      enabled: true
+    CW_003:
       enabled: false

--- a/README.md
+++ b/README.md
@@ -64,6 +64,40 @@ This section lists the various violations that this tool can detect in AWS Cloud
 | CW-002 | The log group has no retention policy. Consider setting a retention policy to save costs and improve log management efficiency. | true |
 | CW-003 | The log group is using STANDARD class. Consider using INFREQUENT_ACCESS to save costs. | false |
 
+## Configuration
+
+### AWS CloudFormation
+
+To configure the Cloud Cost Saver for AWS CloudFormation, create a `.cloudsaving.yaml` file in the root of your project. This file should contain the following settings:
+
+```yaml
+cloudformation:
+    rules:
+        LAMBDA_001:
+            enabled: true
+        LAMBDA_002:
+            enabled: true
+        LAMBDA_003:
+            enabled: true
+            values:
+                - tag1
+                - tag2
+        CW_001:
+            enabled: true
+            threshold: 14
+        CW_002:
+            enabled: true
+        CW_003:
+            enabled: false
+```
+
+In this configuration:
+- `LAMBDA_001`, `LAMBDA_002`, and `LAMBDA_003` are enabled, with `LAMBDA_003` requiring specific tags (`tag1` and `tag2`).
+- `CW_001` is enabled with a threshold of 14 days for log retention.
+- `CW_002` is enabled to ensure log groups have a retention policy.
+- `CW_003` is disabled, meaning it will not check for the use of the `INFREQUENT_ACCESS` class for log groups.
+
+
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request on GitHub.

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -28,7 +28,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
 
     pub(crate) fn run_checks(&mut self) {
         if let Some(rule_config) = &self.config.cloudformation {
-            if rule_config.enabled(RuleType::LambdaMissingTag) {
+            if rule_config.enabled(RuleType::LAMBDA_003) {
                 aws::lambda::check_lambda_missing_tag(
                     self.infra_template,
                     rule_config,
@@ -36,7 +36,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                     self.line_marker,
                 );
             }
-            if rule_config.enabled(RuleType::LambdaArchitectureARM) {
+            if rule_config.enabled(RuleType::LAMBDA_002) {
                 aws::lambda::check_lambda_architecture_arm(
                     self.infra_template,
                     self.error_reporter,
@@ -44,7 +44,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                 );
             }
 
-            if rule_config.enabled(RuleType::LambdaMissingLogGroup) {
+            if rule_config.enabled(RuleType::LAMBDA_001) {
                 aws::lambda::check_lambda_missing_log_group(
                     self.infra_template,
                     self.error_reporter,
@@ -52,7 +52,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                 );
             }
 
-            if rule_config.enabled(RuleType::CWLogRetentionPolicy) {
+            if rule_config.enabled(RuleType::CW_001) || rule_config.enabled(RuleType::CW_002) {
                 aws::cloudwatch::check_cloudwatch_log_group_retention(
                     self.infra_template,
                     rule_config,
@@ -61,7 +61,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                 );
             }
 
-            if rule_config.enabled(RuleType::CWInfrequentAccessLogGroupClass) {
+            if rule_config.enabled(RuleType::CW_003) {
                 aws::cloudwatch::check_cloudwatch_log_group_class(
                     self.infra_template,
                     self.error_reporter,
@@ -215,7 +215,7 @@ mod tests_cfn {
         #[rstest]
         #[case(
             "cfn-testing.yaml",
-            RuleType::LambdaMissingTag,
+            RuleType::LAMBDA_003,
             Some(RuleTypeConfigDetail::Values {
                 values: vec![String::from("tag1")]
             }),
@@ -223,13 +223,13 @@ mod tests_cfn {
         )]
         #[case(
             "cfn-testing.yaml",
-            RuleType::LambdaArchitectureARM,
+            RuleType::LAMBDA_002,
             None,
             LambdaViolation::ARMArchitecture
         )]
         #[case(
             "cfn-testing.yaml",
-            RuleType::LambdaMissingLogGroup,
+            RuleType::LAMBDA_001,
             None,
             LambdaViolation::MissingLogGroup
         )]
@@ -254,13 +254,13 @@ mod tests_cfn {
         #[rstest]
         #[case(
             "cfn-testing.yaml",
-            RuleType::CWLogRetentionPolicy,
+            RuleType::CW_001,
             Some(RuleTypeConfigDetail::Threshold { threshold: (14) }),
             CloudWatchViolation::LogRetentionTooLong,
         )]
         #[case(
             "cfn-testing.yaml",
-            RuleType::CWLogRetentionPolicy,
+            RuleType::CW_002,
             None,
             CloudWatchViolation::NoLogRetention
         )]
@@ -288,7 +288,7 @@ mod tests_cfn {
         #[rstest]
         #[case(
             "cfn-testing.yaml",
-            RuleType::CWInfrequentAccessLogGroupClass,
+            RuleType::CW_003,
             None,
             CloudWatchViolation::InfrequentAccessLogGroupClass
         )]

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -106,7 +106,7 @@ mod tests_cfn {
                 .collect();
             for (i, expected) in self.0.iter().enumerate() {
                 let expected_str = format!(
-                    "{}: {}: {}",
+                    "{}:{}:{}",
                     expected.code, expected.resource, expected.message
                 );
                 let actual_line = actual_lines.get(i).unwrap_or(&"");

--- a/src/error_reporter.rs
+++ b/src/error_reporter.rs
@@ -58,7 +58,7 @@ impl ErrorReporter {
                     self.file_path.clone()
                 };
                 format!(
-                    "{}: {}: {}\n{}\n",
+                    "{}:{}:{}\n{}\n",
                     e.violation.code(),
                     e.resource_name,
                     e.violation.message(),

--- a/src/fixtures/.cloudsaving.yaml
+++ b/src/fixtures/.cloudsaving.yaml
@@ -1,16 +1,18 @@
 cloudformation:
   rules:
-    LambdaMissingLogGroup:
+    LAMBDA_001:
       enabled: true
-    LambdaArchitectureARM:
+    LAMBDA_002:
       enabled: true
-    LambdaMissingTag:
+    LAMBDA_003:
       enabled: true
       values:
         - tag1
         - tag2
-    CWLogRetentionPolicy:
+    CW_001:
       enabled: true
       threshold: 14
-    CWInfrequentAccessLogGroupClass:
+    CW_002:
+      enabled: true
+    CW_003:
       enabled: false

--- a/src/parsers/config.rs
+++ b/src/parsers/config.rs
@@ -61,11 +61,12 @@ impl RuleTypeConfigDetail {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum RuleType {
-    LambdaMissingTag,
-    LambdaArchitectureARM,
-    LambdaMissingLogGroup,
-    CWLogRetentionPolicy,
-    CWInfrequentAccessLogGroupClass,
+    LAMBDA_001,
+    LAMBDA_002,
+    LAMBDA_003,
+    CW_001,
+    CW_002,
+    CW_003,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -85,35 +86,42 @@ impl Default for RuleConfig {
 
         // Default configurations for each rule
         rules.insert(
-            RuleType::LambdaMissingTag,
+            RuleType::LAMBDA_003,
             RuleTypeConfig {
                 enabled: true,
                 config_detail: RuleTypeConfigDetail::Values { values: vec![] },
             },
         );
         rules.insert(
-            RuleType::LambdaArchitectureARM,
+            RuleType::LAMBDA_002,
             RuleTypeConfig {
                 enabled: true,
                 config_detail: RuleTypeConfigDetail::Simple,
             },
         );
         rules.insert(
-            RuleType::LambdaMissingLogGroup,
+            RuleType::LAMBDA_001,
             RuleTypeConfig {
                 enabled: true,
                 config_detail: RuleTypeConfigDetail::Simple,
             },
         );
         rules.insert(
-            RuleType::CWLogRetentionPolicy,
+            RuleType::CW_001,
             RuleTypeConfig {
                 enabled: true,
                 config_detail: RuleTypeConfigDetail::Threshold { threshold: 30 },
             },
         );
         rules.insert(
-            RuleType::CWInfrequentAccessLogGroupClass,
+            RuleType::CW_002,
+            RuleTypeConfig {
+                enabled: true,
+                config_detail: RuleTypeConfigDetail::Simple,
+            },
+        );
+        rules.insert(
+            RuleType::CW_003,
             RuleTypeConfig {
                 enabled: false,
                 config_detail: RuleTypeConfigDetail::Simple,
@@ -169,16 +177,13 @@ mod tests {
         assert!(config.cloudformation.is_some());
         let cloudformation = config.cloudformation.unwrap();
 
-        assert!(cloudformation.enabled(RuleType::LambdaMissingTag));
-        assert!(cloudformation.enabled(RuleType::LambdaArchitectureARM));
-        assert!(cloudformation.enabled(RuleType::LambdaMissingLogGroup));
-        assert!(cloudformation.enabled(RuleType::CWLogRetentionPolicy));
-        assert!(!cloudformation.enabled(RuleType::CWInfrequentAccessLogGroupClass));
+        assert!(cloudformation.enabled(RuleType::LAMBDA_003));
+        assert!(cloudformation.enabled(RuleType::LAMBDA_002));
+        assert!(cloudformation.enabled(RuleType::LAMBDA_001));
+        assert!(cloudformation.enabled(RuleType::CW_001));
+        assert!(!cloudformation.enabled(RuleType::CW_003));
 
-        let cw_log_retention_policy = cloudformation
-            .rules
-            .get(&RuleType::CWLogRetentionPolicy)
-            .unwrap();
+        let cw_log_retention_policy = cloudformation.rules.get(&RuleType::CW_001).unwrap();
         assert_eq!(
             cw_log_retention_policy
                 .config_detail
@@ -195,25 +200,16 @@ mod tests {
         assert!(config.cloudformation.is_some());
         let cloudformation = config.cloudformation.unwrap();
 
-        let lambda_architecture_arm = cloudformation
-            .rules
-            .get(&RuleType::LambdaArchitectureARM)
-            .unwrap();
+        let lambda_architecture_arm = cloudformation.rules.get(&RuleType::LAMBDA_002).unwrap();
         assert!(lambda_architecture_arm.enabled);
 
-        let lambda_missing_tag = cloudformation
-            .rules
-            .get(&RuleType::LambdaMissingTag)
-            .unwrap();
+        let lambda_missing_tag = cloudformation.rules.get(&RuleType::LAMBDA_003).unwrap();
         assert_eq!(
             lambda_missing_tag.config_detail.get_values().unwrap(),
             &vec!["tag1".to_string(), "tag2".to_string()]
         );
 
-        let cw_log_retention_policy = cloudformation
-            .rules
-            .get(&RuleType::CWLogRetentionPolicy)
-            .unwrap();
+        let cw_log_retention_policy = cloudformation.rules.get(&RuleType::CW_001).unwrap();
         assert_eq!(
             cw_log_retention_policy
                 .config_detail
@@ -229,7 +225,7 @@ mod tests {
         let yaml = r#"
         cloudformation:
           rules:
-            LambdaMissingLogGroup:
+            LAMBDA_002:
               threshold: 14
         "#;
 

--- a/src/parsers/config.rs
+++ b/src/parsers/config.rs
@@ -60,6 +60,7 @@ impl RuleTypeConfigDetail {
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[allow(non_camel_case_types)]
 pub enum RuleType {
     LAMBDA_001,
     LAMBDA_002,

--- a/src/rules/aws/cloudwatch.rs
+++ b/src/rules/aws/cloudwatch.rs
@@ -72,7 +72,7 @@ pub fn check_cloudwatch_log_group_class<L: LineMarker>(
                 if let AWSResourceType::CloudWatch = &resource.type_ {
                     if let Some(properties) = &resource.properties {
                         if let Some(log_group_class) = properties.get("LogGroupClass") {
-                            if log_group_class.as_str().map_or(false, |v| v == "STANDARD") {
+                            if log_group_class.as_str() == Some("STANDARD") {
                                 error_reporter.add_error(
                                     Box::new(CloudWatchViolation::InfrequentAccessLogGroupClass),
                                     key,

--- a/src/rules/aws/cloudwatch.rs
+++ b/src/rules/aws/cloudwatch.rs
@@ -17,8 +17,11 @@ pub fn check_cloudwatch_log_group_retention<L: LineMarker>(
                 if let AWSResourceType::CloudWatch = &resource.type_ {
                     if let Some(properties) = &resource.properties {
                         if let Some(retention) = properties.get("RetentionInDays") {
+                            if !rule_config.enabled(RuleType::CW_001) {
+                                continue;
+                            }
                             if let Some(log_retention_days) =
-                                rule_config.rules.get(&RuleType::CWLogRetentionPolicy)
+                                rule_config.rules.get(&RuleType::CW_001)
                             {
                                 if let Some(threshold) =
                                     log_retention_days.config_detail.get_threshold()
@@ -40,6 +43,9 @@ pub fn check_cloudwatch_log_group_retention<L: LineMarker>(
                                 }
                             }
                         } else {
+                            if !rule_config.enabled(RuleType::CW_002) {
+                                continue;
+                            }
                             error_reporter.add_error(
                                 Box::new(CloudWatchViolation::NoLogRetention),
                                 key,

--- a/src/rules/aws/lambda.rs
+++ b/src/rules/aws/lambda.rs
@@ -18,7 +18,7 @@ pub fn check_lambda_missing_tag<L: LineMarker>(
                     if let Some(properties) = &resource.properties {
                         if let Some(tags) = properties.get("Tags") {
                             if let Some(rule_type) =
-                                rule_config.rules.get(&RuleType::LambdaMissingTag)
+                                rule_config.rules.get(&RuleType::LAMBDA_003)
                             {
                                 if let Some(target_tags) = rule_type.config_detail.get_values() {
                                     // Check if at least one tag is defined in the resource

--- a/src/rules/aws/lambda.rs
+++ b/src/rules/aws/lambda.rs
@@ -17,9 +17,7 @@ pub fn check_lambda_missing_tag<L: LineMarker>(
                 if let AWSResourceType::LambdaFunction = &resource.type_ {
                     if let Some(properties) = &resource.properties {
                         if let Some(tags) = properties.get("Tags") {
-                            if let Some(rule_type) =
-                                rule_config.rules.get(&RuleType::LAMBDA_003)
-                            {
+                            if let Some(rule_type) = rule_config.rules.get(&RuleType::LAMBDA_003) {
                                 if let Some(target_tags) = rule_type.config_detail.get_values() {
                                     // Check if at least one tag is defined in the resource
                                     let tag_exists = target_tags.iter().any(|target_tag| {


### PR DESCRIPTION
This pull request includes significant changes to the configuration and rule types for AWS CloudFormation checks. The most important changes involve renaming rule types, updating the configuration file format, and modifying the associated checks and tests.

### Renaming Rule Types:
* Renamed rule types in `src/checker.rs`, `src/parsers/config.rs`, and `src/rules/aws/*` files to use a new naming convention (e.g., `LambdaMissingTag` to `LAMBDA_003`, `CWLogRetentionPolicy` to `CW_001`). [[1]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL31-R55) [[2]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cR63-R70) [[3]](diffhunk://#diff-13e28caeadb499fcd8235e6c822e6843cf8e78a90833ef7846e134f6d5d7671aR20-R24)

### Configuration File Updates:
* Updated `.cloudsaving.yaml` and `src/fixtures/.cloudsaving.yaml` to reflect the new rule type names and added a new section in the `README.md` to explain the configuration settings. [[1]](diffhunk://#diff-2490ca58b09a72efe12937b1aa8c94b6158dace62e56083801b6749054033239L3-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R100)

### Code Modifications:
* Modified the `Checker` implementation in `src/checker.rs` to use the new rule type names in the `run_checks` method. [[1]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL31-R55) [[2]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL64-R64)
* Updated the `RuleTypeConfigDetail` and `RuleConfig` implementations in `src/parsers/config.rs` to use the new rule type names and added an `#[allow(non_camel_case_types)]` attribute. [[1]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cR63-R70) [[2]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cL88-R125)

### Test Updates:
* Updated tests in `src/checker.rs` and `src/parsers/config.rs` to use the new rule type names and ensured they reflect the updated configuration. [[1]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL218-R232) [[2]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL257-R263) [[3]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cL172-R187)

### Additional Code Adjustments:
* Made minor adjustments in `src/rules/aws/cloudwatch.rs` and `src/rules/aws/lambda.rs` to use the new rule type names and improve code readability. [[1]](diffhunk://#diff-13e28caeadb499fcd8235e6c822e6843cf8e78a90833ef7846e134f6d5d7671aR20-R24) [[2]](diffhunk://#diff-13e28caeadb499fcd8235e6c822e6843cf8e78a90833ef7846e134f6d5d7671aL69-R75) [[3]](diffhunk://#diff-bf9440640da19007a141da5950f2f200b422056bd2a1299ae668b9906e69f899L21-R21)