### PR TITLE
Apply globals to lambda properties

### DIFF
--- a/src/fixtures/aws/cfn-parsing-test.yaml
+++ b/src/fixtures/aws/cfn-parsing-test.yaml
@@ -41,6 +41,10 @@ Resources:
       Handler: "index.handler"
       CodeUri: .
       Role: "arn:aws:iam::123456789012:role/execution_role"
+      Environment:
+        Variables:
+          DATABASE_NAME: !Ref DatabaseName
+          LOG_LEVEL: ERROR
 
 Outputs:
   ExampleOutput:


### PR DESCRIPTION
This pull request adds support for applying global environment variables to AWS Lambda functions in CloudFormation templates. The changes include updates to the test fixtures, the CloudFormation parser, and the associated tests.

Key changes:

* **Environment Variable Support in Test Fixtures:**
  * Added `Environment` and `Variables` properties to the `Resources` section in `src/fixtures/aws/cfn-parsing-test.yaml`.

* **CloudFormation Parser Enhancements:**
  * Modified the `CloudFormation` implementation in `src/parsers/cfn.rs` to apply global environment variables to Lambda function resources.

* **Test Updates:**
  * Added checks in `src/parsers/cfn.rs` to verify that global environment variables are correctly applied to Lambda function resources in the test cases.