### PR TITLE
Refactor/resolve globals 2

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -157,7 +157,10 @@ mod tests_cfn {
         }
 
         fn get_cloudformation(path: &str) -> CloudFormation {
-            parse_cloudformation(&format!("src/fixtures/aws/{}", path)).unwrap()
+            let mut parsed_cfn =
+                parse_cloudformation(&format!("src/fixtures/aws/{}", path)).unwrap();
+            parsed_cfn.resolve_parameters(None, None);
+            parsed_cfn
         }
 
         fn get_line_marker(path: &str) -> YamlLineMarker {

--- a/src/fixtures/aws/cfn-parsing-test.yaml
+++ b/src/fixtures/aws/cfn-parsing-test.yaml
@@ -18,6 +18,10 @@ Parameters:
 Globals:
   Function:
     Timeout: 60
+    EventInvokeConfig:
+      MaximumRetryAttempts: 0
+    Architectures:
+      - arm64
     Environment:
       Variables:
         LOG_LEVEL: !Ref LogLevel

--- a/src/parsers/cfn.rs
+++ b/src/parsers/cfn.rs
@@ -447,7 +447,7 @@ mod test {
         );
         assert_eq!(cloudformation.parameters.unwrap().len(), 4);
         assert_eq!(cloudformation.mappings.unwrap().len(), 1);
-        assert_eq!(cloudformation.globals.unwrap().function.unwrap().len(), 2);
+        assert_eq!(cloudformation.globals.unwrap().function.unwrap().len(), 4);
         assert_eq!(cloudformation.resources.unwrap().len(), 1);
         assert_eq!(cloudformation.outputs.unwrap().len(), 1);
     }

--- a/src/parsers/cfn.rs
+++ b/src/parsers/cfn.rs
@@ -151,15 +151,16 @@ impl CloudFormation {
                 if let AWSResourceType::LambdaFunction | AWSResourceType::LambdaServerlessFunction =
                     &resource.type_
                 {
-                    if let Some(global_function_envs) = self
-                        .globals
-                        .as_ref()
-                        .and_then(|g| g.function.as_ref())
-                        .and_then(|f| f.get("Environment"))
-                        .and_then(|e| e.get("Variables"))
-                        .and_then(|v| v.as_mapping())
+                    if let Some(global_function_settings) =
+                        self.globals.as_ref().and_then(|g| g.function.as_ref())
                     {
                         if let Some(properties) = resource.properties.as_mut() {
+                            // Apply global function environment variables to the resource
+                            let global_function_envs = global_function_settings
+                                .get("Environment")
+                                .and_then(|e| e.get("Variables"))
+                                .and_then(|v| v.as_mapping());
+
                             let env_vars = properties
                                 .entry("Environment".to_string())
                                 .or_insert_with(|| {
@@ -174,8 +175,30 @@ impl CloudFormation {
                                 .as_mapping_mut()
                                 .unwrap();
 
-                            for (k, v) in global_function_envs {
-                                env_vars.entry(k.clone()).or_insert_with(|| v.clone());
+                            if let Some(global_function_envs) = global_function_envs {
+                                for (k, v) in global_function_envs {
+                                    env_vars.entry(k.clone()).or_insert_with(|| v.clone());
+                                }
+                            }
+
+                            // Apply architecture
+                            if let Some(architecture) =
+                                global_function_settings.get("Architectures")
+                            {
+                                properties
+                                    .entry("Architectures".to_string())
+                                    .or_insert_with(|| architecture.clone());
+                            }
+
+                            // Apply event maximum retry attempts for serverless lambda function
+                            if let Some(event_invoke_config) =
+                                global_function_settings.get("EventInvokeConfig")
+                            {
+                                if let AWSResourceType::LambdaServerlessFunction = &resource.type_ {
+                                    properties
+                                        .entry("EventInvokeConfig".to_string())
+                                        .or_insert_with(|| event_invoke_config.clone());
+                                }
                             }
                         }
                     }
@@ -476,6 +499,21 @@ mod test {
             .get("POWERTOOLS_LOGGER_SAMPLE_RATE")
             .unwrap();
         assert_eq!(powertools_logger_sample_rate, &serde_yaml::Value::from(1));
+
+        // Check if the global architecture is applied to the resources
+        let architecture = properties.get("Architectures").unwrap();
+        assert_eq!(architecture, &serde_yaml::Value::from(vec!["arm64"]));
+        // Check if the global event invoke config is applied to the resources
+        let event_invoke_config = properties.get("EventInvokeConfig").unwrap();
+        let mut expected_mapping = serde_yaml::Mapping::new();
+        expected_mapping.insert(
+            serde_yaml::Value::String("MaximumRetryAttempts".to_string()),
+            serde_yaml::Value::Number(serde_yaml::Number::from(0)),
+        );
+        assert_eq!(
+            event_invoke_config,
+            &serde_yaml::Value::Mapping(expected_mapping)
+        );
     }
 
     #[test]


### PR DESCRIPTION
This pull request includes several changes to the CloudFormation parser and related tests. The main focus is on adding support for new global function settings and simplifying the handling of maximum retry attempts for Lambda functions.

Improvements to CloudFormation parser:

* [`src/checker.rs`](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL160-R163): Modified `get_cloudformation` function to resolve parameters after parsing.
* [`src/parsers/cfn.rs`](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L154-R163): Enhanced the `CloudFormation` implementation to apply global function environment variables, architectures, and event invoke configurations to resources. [[1]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L154-R163) [[2]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20R178-R203)

Updates to test cases:

* [`src/fixtures/aws/cfn-parsing-test.yaml`](diffhunk://#diff-acfe7202d36dfb2f5fc9018242396b79d98cd8d86bc6c5ee6dc817d32a9f760eR21-R24): Added new global function settings for `EventInvokeConfig` and `Architectures`.
* [`src/parsers/cfn.rs`](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L427-R450): Updated test cases to check for new global settings and ensure they are applied correctly to resources. [[1]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L427-R450) [[2]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20R502-R516)

Simplification of Lambda maximum retry attempts check:

* [`src/rules/aws/lambda.rs`](diffhunk://#diff-bf9440640da19007a141da5950f2f200b422056bd2a1299ae668b9906e69f899L153-L161): Removed redundant code for checking global maximum retry attempts and simplified the logic to fetch and validate the retry attempts from the resource properties. [[1]](diffhunk://#diff-bf9440640da19007a141da5950f2f200b422056bd2a1299ae668b9906e69f899L153-L161) [[2]](diffhunk://#diff-bf9440640da19007a141da5950f2f200b422056bd2a1299ae668b9906e69f899L174) [[3]](diffhunk://#diff-bf9440640da19007a141da5950f2f200b422056bd2a1299ae668b9906e69f899L199-L210)