### PR TITLE
Feature/lambda 007

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This section lists the various violations that this tool can detect in AWS Cloud
 | LAMBDA-004 | Asynchronously invoked Lambda functions have a default maximum retry attempts set to 2. Consider setting the maximum retry attempts to 0 to prevent unnecessary retries. For example, if your Lambda function is invoked via an SQS queue with 3 retries, a failure event may result in up to 9 retries. | true |
 | LAMBDA-005 | Set the POWERTOOLS_LOG_LEVEL environment variable to appropriate logging levels for different environments when using AWS Lambda Powertools. This helps in reducing logging costs. | false |
 | LAMBDA-006 | Logging every incoming event may significantly increase cloud costs. Consider disabling POWERTOOLS_LOGGER_LOG_EVENT in the production environment to help reduce logging expenses. | true |
+| LAMBDA-007 | Set the POWERTOOLS_LOGGER_SAMPLE_RATE environment variable to a value between 0 and 1 to sample logs and reduce logging costs when using AWS Lambda Powertools. | false |
 
 #### CloudWatch
 
@@ -118,6 +119,7 @@ The `.cloudsaving.yaml` file allows you to customize the behavior of the Cloud C
 | LAMBDA_004 | Threshold          | Lambda maximum retry attempts |
 | LAMBDA_005 | Value              | POWERTOOLS_LOG_LEVEL value |
 | LAMBDA_006 | Simple             | Enable to check if POWERTOOLS_LOGGER_LOG_EVENT is set to false |
+| LAMBDA_007 | Threshold          | Set sample rate with POWERTOOLS_LOGGER_SAMPLE_RATE |
 | CW_001     | Threshold          | Log retention period in days |
 | CW_002     | Simple             | Enabled or not |
 | CW_003     | Simple             | Enabled or not |

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -63,6 +63,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
 
             if rule_config.enabled(RuleType::LAMBDA_005)
                 || rule_config.enabled(RuleType::LAMBDA_006)
+                || rule_config.enabled(RuleType::LAMBDA_007)
             {
                 aws::lambda::check_lambda_powertools_environment_variables(
                     self.infra_template,
@@ -144,7 +145,9 @@ mod tests_cfn {
         use crate::checker::Checker;
         use crate::error_reporter::ErrorReporter;
         use crate::parsers::cfn::{parse_cloudformation, CloudFormation};
-        use crate::parsers::config::{Config, RuleConfig, RuleType, RuleTypeConfigDetail};
+        use crate::parsers::config::{
+            Config, RuleConfig, RuleType, RuleTypeConfigDetail, ThresholdValue,
+        };
         use crate::parsers::get_yaml_line_marker;
         use crate::parsers::iac::InfratructureTemplate;
         use crate::parsers::YamlLineMarker;
@@ -278,7 +281,7 @@ mod tests_cfn {
         #[case(
             "cfn-lambda-examples.yaml",
             RuleType::LAMBDA_004,
-            Some(RuleTypeConfigDetail::Threshold { threshold: 0 }),
+            Some(RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(0) }),
             LambdaViolation::MaximumRetryAttempts
         )]
         fn test_lambda_004(
@@ -302,17 +305,11 @@ mod tests_cfn {
         #[rstest]
         #[case(
             "cfn-lambda-examples.yaml",
-            RuleType::LAMBDA_005,
-            Some(RuleTypeConfigDetail::Value { value: "ERROR".to_string() }),
-            LambdaViolation::PowertoolsLogLevel
+            RuleType::LAMBDA_007,
+            Some(RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Float(0.5) }),
+            LambdaViolation::PowertoolsLoggerSampleRate
         )]
-        #[case(
-            "cfn-lambda-examples.yaml",
-            RuleType::LAMBDA_006,
-            None,
-            LambdaViolation::PowertoolsLoggerLogEvent
-        )]
-        fn test_lambda_005_006(
+        fn test_lambda_005_006_007(
             #[case] template_name: &str,
             #[case] rule_type: RuleType,
             #[case] config_detail: Option<RuleTypeConfigDetail>,
@@ -334,7 +331,7 @@ mod tests_cfn {
         #[case(
             "cfn-testing.yaml",
             RuleType::CW_001,
-            Some(RuleTypeConfigDetail::Threshold { threshold: (14) }),
+            Some(RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(14) }),
             CloudWatchViolation::LogRetentionTooLong,
         )]
         #[case(

--- a/src/fixtures/aws/cfn-lambda-examples.yaml
+++ b/src/fixtures/aws/cfn-lambda-examples.yaml
@@ -9,6 +9,7 @@ Globals:
       Variables:
         POWERTOOLS_LOG_LEVEL: "ERROR"
         POWERTOOLS_LOGGER_LOG_EVENT: true
+        POWERTOOLS_LOGGER_SAMPLE_RATE: 0.5
 
 Resources:
   MyLambdaFunction:
@@ -23,6 +24,7 @@ Resources:
       Environment:
         Variables:
           POWERTOOLS_LOG_LEVEL: "INFO"
+          POWERTOOLS_LOGGER_SAMPLE_RATE: 1
 
   MyLambdaFunction2:
     Type: AWS::Serverless::Function

--- a/src/parsers/config.rs
+++ b/src/parsers/config.rs
@@ -78,19 +78,21 @@ impl RuleTypeConfigDetail {
     }
 
     pub fn get_threshold_int(&self) -> Option<u64> {
-        if let RuleTypeConfigDetail::Threshold { threshold } = self {
-            if let ThresholdValue::Int(value) = threshold {
-                return Some(*value);
-            }
+        if let RuleTypeConfigDetail::Threshold {
+            threshold: ThresholdValue::Int(value),
+        } = self
+        {
+            return Some(*value);
         }
         None
     }
 
     pub fn get_threshold_float(&self) -> Option<f64> {
-        if let RuleTypeConfigDetail::Threshold { threshold } = self {
-            if let ThresholdValue::Float(value) = threshold {
-                return Some(*value);
-            }
+        if let RuleTypeConfigDetail::Threshold {
+            threshold: ThresholdValue::Float(value),
+        } = self
+        {
+            return Some(*value);
         }
         None
     }

--- a/src/rules/aws/cloudwatch.rs
+++ b/src/rules/aws/cloudwatch.rs
@@ -24,7 +24,7 @@ pub fn check_cloudwatch_log_group_retention<L: LineMarker>(
                                 rule_config.rules.get(&RuleType::CW_001)
                             {
                                 if let Some(threshold) =
-                                    log_retention_days.config_detail.get_threshold()
+                                    log_retention_days.config_detail.get_threshold_int()
                                 {
                                     // Check if the retention period is longer than the threshold
                                     if retention.as_u64().is_none_or(|v| v > threshold) {

--- a/src/rules/violations.rs
+++ b/src/rules/violations.rs
@@ -14,6 +14,7 @@ pub enum LambdaViolation {
     MaximumRetryAttempts,
     PowertoolsLogLevel,
     PowertoolsLoggerLogEvent,
+    PowertoolsLoggerSampleRate,
 }
 
 impl Violation for LambdaViolation {
@@ -45,6 +46,10 @@ impl Violation for LambdaViolation {
             LambdaViolation::PowertoolsLoggerLogEvent => {
                 "Logging every incoming event may significantly increase cloud costs. \
                 Consider disabling POWERTOOLS_LOGGER_LOG_EVENT in the production environment to help reduce logging expenses.".to_string()
+            },
+            LambdaViolation::PowertoolsLoggerSampleRate => {
+                "Set the POWERTOOLS_LOGGER_SAMPLE_RATE environment variable to a value between 0 and 1 \
+                to sample logs and reduce logging costs when using AWS Lambda Powertools.".to_string()
             }
         }
     }
@@ -57,6 +62,7 @@ impl Violation for LambdaViolation {
             LambdaViolation::MaximumRetryAttempts => "LAMBDA-004".to_string(),
             LambdaViolation::PowertoolsLogLevel => "LAMBDA-005".to_string(),
             LambdaViolation::PowertoolsLoggerLogEvent => "LAMBDA-006".to_string(),
+            LambdaViolation::PowertoolsLoggerSampleRate => "LAMBDA-007".to_string(),
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a new rule, `LAMBDA_007`, to the AWS Lambda Powertools environment variables checker and updates the codebase to support threshold values as either integers or floats. The most important changes include updates to the `README.md` file, the `src/checker.rs` file, and the `src/parsers/config.rs` file.

### New Rule Addition:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61): Added a new rule, `LAMBDA-007`, to set the `POWERTOOLS_LOGGER_SAMPLE_RATE` environment variable to a value between 0 and 1 to sample logs and reduce logging costs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R122)

### Code Updates for New Rule:
* [`src/checker.rs`](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faR66): Updated the `Checker` implementation to include the new `LAMBDA_007` rule and added corresponding test cases. [[1]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faR66) [[2]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL147-R150) [[3]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL281-R284) [[4]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL305-R312) [[5]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL337-R334)
* [`src/fixtures/aws/cfn-lambda-examples.yaml`](diffhunk://#diff-df46a57e8befea5ebade5e60602b321eb34824879c729ccbde9fac88139c4f7fR12): Added sample configurations for `POWERTOOLS_LOGGER_SAMPLE_RATE` to the test fixtures. [[1]](diffhunk://#diff-df46a57e8befea5ebade5e60602b321eb34824879c729ccbde9fac88139c4f7fR12) [[2]](diffhunk://#diff-df46a57e8befea5ebade5e60602b321eb34824879c729ccbde9fac88139c4f7fR27)

### Support for Threshold Values:
* [`src/parsers/config.rs`](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cR12-R22): Introduced a new `ThresholdValue` enum to support both integer and float threshold values. Updated the `RuleTypeConfigDetail` to use this new enum and modified related methods and tests. [[1]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cR12-R22) [[2]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cL37-R49) [[3]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cL68-R97) [[4]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cR110) [[5]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cL132-R159) [[6]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cR178-R193) [[7]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cL232-R270) [[8]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cL258-R296)

### Rule Checking Logic:
* [`src/rules/aws/lambda.rs`](diffhunk://#diff-bf9440640da19007a141da5950f2f200b422056bd2a1299ae668b9906e69f899L157-R157): Enhanced the rule checking logic to handle the new `LAMBDA_007` rule and to fetch the threshold value as a float. [[1]](diffhunk://#diff-bf9440640da19007a141da5950f2f200b422056bd2a1299ae668b9906e69f899L157-R157) [[2]](diffhunk://#diff-bf9440640da19007a141da5950f2f200b422056bd2a1299ae668b9906e69f899L215-R217) [[3]](diffhunk://#diff-bf9440640da19007a141da5950f2f200b422056bd2a1299ae668b9906e69f899R240-R243) [[4]](diffhunk://#diff-bf9440640da19007a141da5950f2f200b422056bd2a1299ae668b9906e69f899R264-R298)

### Violation Handling:
* [`src/rules/violations.rs`](diffhunk://#diff-23b134184d358b90e11ca29b941adee69601f49f4214240eb47d8353bc6a4836R17): Added a new violation type, `PowertoolsLoggerSampleRate`, for the `LAMBDA_007` rule and updated the violation messages and codes. [[1]](diffhunk://#diff-23b134184d358b90e11ca29b941adee69601f49f4214240eb47d8353bc6a4836R17) [[2]](diffhunk://#diff-23b134184d358b90e11ca29b941adee69601f49f4214240eb47d8353bc6a4836R49-R52) [[3]](diffhunk://#diff-23b134184d358b90e11ca29b941adee69601f49f4214240eb47d8353bc6a4836R65)