### PR TITLE
Allow overriding rules to different env

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -9,6 +9,7 @@ pub(crate) struct Checker<'a, L: LineMarker + 'a> {
     error_reporter: &'a mut ErrorReporter,
     infra_template: &'a InfratructureTemplate,
     line_marker: &'a L,
+    environment: &'a str,
 }
 
 impl<'a, L: LineMarker + 'a> Checker<'a, L> {
@@ -17,18 +18,20 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
         error_reporter: &'a mut ErrorReporter,
         infra_template: &'a InfratructureTemplate,
         line_marker: &'a L,
+        environment: &'a str,
     ) -> Checker<'a, L> {
         Checker {
             config,
             error_reporter,
             infra_template,
             line_marker,
+            environment,
         }
     }
 
     pub(crate) fn run_checks(&mut self) {
         if let Some(rule_config) = &self.config.cloudformation {
-            if rule_config.enabled(RuleType::LAMBDA_003) {
+            if rule_config.enabled(RuleType::LAMBDA_003, &self.environment) {
                 aws::lambda::check_lambda_missing_tag(
                     self.infra_template,
                     rule_config,
@@ -36,7 +39,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                     self.line_marker,
                 );
             }
-            if rule_config.enabled(RuleType::LAMBDA_002) {
+            if rule_config.enabled(RuleType::LAMBDA_002, &self.environment) {
                 aws::lambda::check_lambda_architecture_arm(
                     self.infra_template,
                     self.error_reporter,
@@ -44,7 +47,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                 );
             }
 
-            if rule_config.enabled(RuleType::LAMBDA_001) {
+            if rule_config.enabled(RuleType::LAMBDA_001, &self.environment) {
                 aws::lambda::check_lambda_missing_log_group(
                     self.infra_template,
                     self.error_reporter,
@@ -52,7 +55,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                 );
             }
 
-            if rule_config.enabled(RuleType::LAMBDA_004) {
+            if rule_config.enabled(RuleType::LAMBDA_004, &self.environment) {
                 aws::lambda::check_lambda_maxmimum_retry_attempts(
                     self.infra_template,
                     rule_config,
@@ -61,28 +64,32 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                 );
             }
 
-            if rule_config.enabled(RuleType::LAMBDA_005)
-                || rule_config.enabled(RuleType::LAMBDA_006)
-                || rule_config.enabled(RuleType::LAMBDA_007)
+            if rule_config.enabled(RuleType::LAMBDA_005, &self.environment)
+                || rule_config.enabled(RuleType::LAMBDA_006, &self.environment)
+                || rule_config.enabled(RuleType::LAMBDA_007, &self.environment)
             {
                 aws::lambda::check_lambda_powertools_environment_variables(
                     self.infra_template,
                     rule_config,
                     self.error_reporter,
                     self.line_marker,
+                    &self.environment,
                 );
             }
 
-            if rule_config.enabled(RuleType::CW_001) || rule_config.enabled(RuleType::CW_002) {
+            if rule_config.enabled(RuleType::CW_001, &self.environment)
+                || rule_config.enabled(RuleType::CW_002, &self.environment)
+            {
                 aws::cloudwatch::check_cloudwatch_log_group_retention(
                     self.infra_template,
                     rule_config,
                     self.error_reporter,
                     self.line_marker,
+                    &self.environment,
                 );
             }
 
-            if rule_config.enabled(RuleType::CW_003) {
+            if rule_config.enabled(RuleType::CW_003, &self.environment) {
                 aws::cloudwatch::check_cloudwatch_log_group_class(
                     self.infra_template,
                     self.error_reporter,
@@ -160,6 +167,10 @@ mod tests_cfn {
             for rule in default_rule_config.rules.values_mut() {
                 rule.enabled = false;
             }
+            default_rule_config.environments.insert(
+                "default".to_string(),
+                Some(default_rule_config.rules.clone()),
+            );
 
             Config {
                 cloudformation: Some(default_rule_config),
@@ -173,7 +184,7 @@ mod tests_cfn {
         fn get_cloudformation(path: &str) -> CloudFormation {
             let mut parsed_cfn =
                 parse_cloudformation(&format!("src/fixtures/aws/{}", path)).unwrap();
-            parsed_cfn.resolve_parameters(None, None);
+            parsed_cfn.resolve_parameters(None, "default");
             parsed_cfn
         }
 
@@ -187,11 +198,7 @@ mod tests_cfn {
             config_detail: Option<RuleTypeConfigDetail>,
         ) {
             if let Some(cloudformation) = &mut config.cloudformation {
-                let rule = cloudformation.rules.get_mut(&rule_type).unwrap();
-                rule.enabled = true;
-                if let Some(detail) = config_detail {
-                    rule.config_detail = detail;
-                }
+                cloudformation.set_rule(rule_type, true, "default", config_detail.as_ref());
             }
         }
 
@@ -227,6 +234,7 @@ mod tests_cfn {
                     &mut self.error_reporter,
                     &self.infra_template,
                     &self.line_marker,
+                    "default",
                 )
             }
         }

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -198,7 +198,14 @@ mod tests_cfn {
             config_detail: Option<RuleTypeConfigDetail>,
         ) {
             if let Some(cloudformation) = &mut config.cloudformation {
-                cloudformation.set_rule(rule_type, true, "default", config_detail.as_ref());
+                if let Some(Some(env)) = cloudformation.environments.get_mut("default") {
+                    if let Some(rule) = env.get_mut(&rule_type) {
+                        rule.enabled = true;
+                        if let Some(config_detail) = config_detail {
+                            rule.config_detail = config_detail.clone();
+                        }
+                    }
+                }
             }
         }
 

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -31,7 +31,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
 
     pub(crate) fn run_checks(&mut self) {
         if let Some(rule_config) = &self.config.cloudformation {
-            if rule_config.enabled(RuleType::LAMBDA_003, &self.environment) {
+            if rule_config.enabled(RuleType::LAMBDA_003, self.environment) {
                 aws::lambda::check_lambda_missing_tag(
                     self.infra_template,
                     rule_config,
@@ -39,7 +39,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                     self.line_marker,
                 );
             }
-            if rule_config.enabled(RuleType::LAMBDA_002, &self.environment) {
+            if rule_config.enabled(RuleType::LAMBDA_002, self.environment) {
                 aws::lambda::check_lambda_architecture_arm(
                     self.infra_template,
                     self.error_reporter,
@@ -47,7 +47,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                 );
             }
 
-            if rule_config.enabled(RuleType::LAMBDA_001, &self.environment) {
+            if rule_config.enabled(RuleType::LAMBDA_001, self.environment) {
                 aws::lambda::check_lambda_missing_log_group(
                     self.infra_template,
                     self.error_reporter,
@@ -55,7 +55,7 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                 );
             }
 
-            if rule_config.enabled(RuleType::LAMBDA_004, &self.environment) {
+            if rule_config.enabled(RuleType::LAMBDA_004, self.environment) {
                 aws::lambda::check_lambda_maxmimum_retry_attempts(
                     self.infra_template,
                     rule_config,
@@ -64,32 +64,32 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                 );
             }
 
-            if rule_config.enabled(RuleType::LAMBDA_005, &self.environment)
-                || rule_config.enabled(RuleType::LAMBDA_006, &self.environment)
-                || rule_config.enabled(RuleType::LAMBDA_007, &self.environment)
+            if rule_config.enabled(RuleType::LAMBDA_005, self.environment)
+                || rule_config.enabled(RuleType::LAMBDA_006, self.environment)
+                || rule_config.enabled(RuleType::LAMBDA_007, self.environment)
             {
                 aws::lambda::check_lambda_powertools_environment_variables(
                     self.infra_template,
                     rule_config,
                     self.error_reporter,
                     self.line_marker,
-                    &self.environment,
+                    self.environment,
                 );
             }
 
-            if rule_config.enabled(RuleType::CW_001, &self.environment)
-                || rule_config.enabled(RuleType::CW_002, &self.environment)
+            if rule_config.enabled(RuleType::CW_001, self.environment)
+                || rule_config.enabled(RuleType::CW_002, self.environment)
             {
                 aws::cloudwatch::check_cloudwatch_log_group_retention(
                     self.infra_template,
                     rule_config,
                     self.error_reporter,
                     self.line_marker,
-                    &self.environment,
+                    self.environment,
                 );
             }
 
-            if rule_config.enabled(RuleType::CW_003, &self.environment) {
+            if rule_config.enabled(RuleType::CW_003, self.environment) {
                 aws::cloudwatch::check_cloudwatch_log_group_class(
                     self.infra_template,
                     self.error_reporter,

--- a/src/fixtures/.cloudsaving.yaml
+++ b/src/fixtures/.cloudsaving.yaml
@@ -16,3 +16,18 @@ cloudformation:
       enabled: true
     CW_003:
       enabled: false
+  environments:
+    dev:
+    sandbox:
+      LAMBDA_002:
+        enabled: false
+      CW_003:
+        enabled: true
+    prod:
+      LAMBDA_003:
+        enabled: true
+        values:
+          - tag3
+          - tag4
+      CW_002:
+        enabled: false

--- a/src/parsers/cfn.rs
+++ b/src/parsers/cfn.rs
@@ -23,11 +23,11 @@ pub(crate) struct CloudFormation {
 }
 
 impl CloudFormation {
-    pub fn resolve_parameters(&mut self, samconfig: Option<&SamConfig>, environment: Option<&str>) {
+    pub fn resolve_parameters(&mut self, samconfig: Option<&SamConfig>, environment: &str) {
         if let Some(samconfig) = samconfig {
             let samconfig_section = samconfig
                 .environments
-                .get(environment.expect("Environment is None"))
+                .get(environment)
                 .expect("Environment not found in samconfig");
             // Check if the parameter is overridden in the samconfig
             if let Some(sam_deploy_parameters) = samconfig_section.deploy.as_ref() {
@@ -457,7 +457,7 @@ mod test {
         let mut cloudformation =
             parse_cloudformation("src/fixtures/aws/cfn-parsing-test.yaml").unwrap();
         let samconfig = parse_samconfig("src/fixtures/aws/samconfig.toml").unwrap();
-        cloudformation.resolve_parameters(Some(&samconfig), Some("default"));
+        cloudformation.resolve_parameters(Some(&samconfig), "default");
         let parameters = cloudformation.parameters.unwrap();
         let database_name = parameters.get("DatabaseName").unwrap();
         assert_eq!(

--- a/src/parsers/config.rs
+++ b/src/parsers/config.rs
@@ -248,8 +248,8 @@ impl Default for RuleConfig {
         environments.insert("default".to_string(), Some(rules.clone()));
 
         RuleConfig {
-            rules: rules,
-            environments: environments,
+            rules,
+            environments,
         }
     }
 }
@@ -290,7 +290,7 @@ impl Config {
                 .environments
                 .entry("default".to_string())
                 .or_insert_with(|| Some(cloudformation.rules.clone()));
-            for (_env, rules) in &mut cloudformation.environments {
+            for rules in cloudformation.environments.values_mut() {
                 // No override rules, apply default rules
                 if rules.is_none() {
                     rules.replace(cloudformation.rules.clone());
@@ -390,7 +390,7 @@ mod tests {
             .as_ref()
             .unwrap();
         let prod_cw002 = prod_env.get(&RuleType::CW_002).unwrap();
-        assert_eq!(prod_cw002.enabled, false);
+        assert!(!prod_cw002.enabled);
         let prod_lamnda003 = prod_env.get(&RuleType::LAMBDA_003).unwrap();
         assert_eq!(
             prod_lamnda003.config_detail.get_values().unwrap(),

--- a/src/parsers/config.rs
+++ b/src/parsers/config.rs
@@ -1,21 +1,22 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
+use std::hash::Hash;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct RuleTypeConfig {
     pub enabled: bool,
     #[serde(flatten)]
     pub config_detail: RuleTypeConfigDetail,
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize, PartialEq, Clone)]
 pub enum ThresholdValue {
     Int(u64),
     Float(f64),
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq, Clone)]
 pub enum RuleTypeConfigDetail {
     Value { value: String },
     Values { values: Vec<String> },
@@ -98,7 +99,7 @@ impl RuleTypeConfigDetail {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 #[allow(non_camel_case_types)]
 pub enum RuleType {
     LAMBDA_001,
@@ -116,11 +117,47 @@ pub enum RuleType {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RuleConfig {
     pub rules: HashMap<RuleType, RuleTypeConfig>,
+    pub environments: HashMap<String, Option<HashMap<RuleType, RuleTypeConfig>>>,
 }
 
 impl RuleConfig {
-    pub fn enabled(&self, violation: RuleType) -> bool {
-        self.rules.get(&violation).is_some_and(|rule| rule.enabled)
+    pub fn enabled(&self, violation: RuleType, environment: &str) -> bool {
+        if let Some(env) = self.environments.get(environment) {
+            if let Some(rules) = env {
+                if let Some(rule) = rules.get(&violation) {
+                    return rule.enabled;
+                }
+            }
+        }
+        false
+    }
+
+    pub fn set_rule(
+        &mut self,
+        rule: RuleType,
+        enabled: bool,
+        environment: &str,
+        config_detail: Option<&RuleTypeConfigDetail>,
+    ) {
+        if let Some(env) = self.environments.get_mut(environment) {
+            if let Some(rules) = env {
+                if let Some(rule) = rules.get_mut(&rule) {
+                    rule.enabled = enabled;
+                    if config_detail.is_some() {
+                        rule.config_detail = config_detail.cloned().unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn get_rule(&self, rule: RuleType, environment: &str) -> Option<&RuleTypeConfig> {
+        if let Some(env) = self.environments.get(environment) {
+            if let Some(rules) = env {
+                return rules.get(&rule);
+            }
+        }
+        None
     }
 }
 
@@ -207,8 +244,13 @@ impl Default for RuleConfig {
                 config_detail: RuleTypeConfigDetail::Simple,
             },
         );
+        let mut environments = HashMap::new();
+        environments.insert("default".to_string(), Some(rules.clone()));
 
-        RuleConfig { rules }
+        RuleConfig {
+            rules: rules,
+            environments: environments,
+        }
     }
 }
 
@@ -232,13 +274,36 @@ impl Config {
         let mut config: Config = serde_yaml::from_str(&data)?;
 
         // Merge default rules with the loaded configuration
-        let default_rules = RuleConfig::default().rules;
+        let default_rules: HashMap<RuleType, RuleTypeConfig> = RuleConfig::default().rules;
         if let Some(ref mut cloudformation) = config.cloudformation {
             for (rule_name, default_rule) in default_rules {
                 cloudformation
                     .rules
                     .entry(rule_name)
                     .or_insert(default_rule);
+            }
+        }
+
+        if let Some(ref mut cloudformation) = config.cloudformation {
+            // Create `default` environment
+            cloudformation
+                .environments
+                .entry("default".to_string())
+                .or_insert_with(|| Some(cloudformation.rules.clone()));
+            for (_env, rules) in &mut cloudformation.environments {
+                // No override rules, apply default rules
+                if rules.is_none() {
+                    rules.replace(cloudformation.rules.clone());
+                } else {
+                    // Merge default rules with the loaded configuration
+                    if let Some(rules) = rules {
+                        for (rule_name, default_rule) in &cloudformation.rules.clone() {
+                            rules
+                                .entry(rule_name.clone())
+                                .or_insert_with(|| default_rule.clone());
+                        }
+                    }
+                }
             }
         }
 
@@ -257,11 +322,11 @@ mod tests {
         assert!(config.cloudformation.is_some());
         let cloudformation = config.cloudformation.unwrap();
 
-        assert!(!cloudformation.enabled(RuleType::LAMBDA_003));
-        assert!(!cloudformation.enabled(RuleType::LAMBDA_002));
-        assert!(cloudformation.enabled(RuleType::LAMBDA_001));
-        assert!(cloudformation.enabled(RuleType::CW_001));
-        assert!(!cloudformation.enabled(RuleType::CW_003));
+        assert!(!cloudformation.enabled(RuleType::LAMBDA_003, "default"));
+        assert!(!cloudformation.enabled(RuleType::LAMBDA_002, "default"));
+        assert!(cloudformation.enabled(RuleType::LAMBDA_001, "default"));
+        assert!(cloudformation.enabled(RuleType::CW_001, "default"));
+        assert!(!cloudformation.enabled(RuleType::CW_003, "default"));
 
         let cw_log_retention_policy = cloudformation.rules.get(&RuleType::CW_001).unwrap();
         assert_eq!(
@@ -297,6 +362,40 @@ mod tests {
                 .unwrap(),
             14
         );
+
+        dbg!(&cloudformation.environments);
+        let default_env = cloudformation
+            .environments
+            .get("default")
+            .unwrap()
+            .as_ref()
+            .unwrap();
+        assert_eq!(default_env.len(), cloudformation.rules.len());
+
+        // No override rules, apply default rules
+        let dev_env = cloudformation
+            .environments
+            .get("dev")
+            .unwrap()
+            .as_ref()
+            .unwrap();
+        assert!(dev_env
+            .iter()
+            .all(|(k, v)| default_env.get(k).map_or(false, |dv| dv == v)));
+
+        let prod_env = cloudformation
+            .environments
+            .get("prod")
+            .unwrap()
+            .as_ref()
+            .unwrap();
+        let prod_cw002 = prod_env.get(&RuleType::CW_002).unwrap();
+        assert_eq!(prod_cw002.enabled, false);
+        let prod_lamnda003 = prod_env.get(&RuleType::LAMBDA_003).unwrap();
+        assert_eq!(
+            prod_lamnda003.config_detail.get_values().unwrap(),
+            &vec!["tag3".to_string(), "tag4".to_string()]
+        );
     }
 
     #[test]
@@ -310,5 +409,15 @@ mod tests {
         "#;
 
         let _: Config = from_str(yaml).unwrap();
+    }
+
+    #[test]
+    fn test_default_environment() {
+        let config = Config::default();
+        let cloudformation = config.cloudformation.unwrap();
+
+        // Test with default environment
+        assert!(cloudformation.enabled(RuleType::LAMBDA_001, "default"));
+        assert!(!cloudformation.enabled(RuleType::LAMBDA_003, "default"));
     }
 }

--- a/src/rules/aws/cloudwatch.rs
+++ b/src/rules/aws/cloudwatch.rs
@@ -18,11 +18,11 @@ pub fn check_cloudwatch_log_group_retention<L: LineMarker>(
                 if let AWSResourceType::CloudWatch = &resource.type_ {
                     if let Some(properties) = &resource.properties {
                         if let Some(retention) = properties.get("RetentionInDays") {
-                            if !rule_config.enabled(RuleType::CW_001, &environment) {
+                            if !rule_config.enabled(RuleType::CW_001, environment) {
                                 continue;
                             }
                             if let Some(log_retention_days) =
-                                rule_config.get_rule(RuleType::CW_001, &environment)
+                                rule_config.get_rule(RuleType::CW_001, environment)
                             {
                                 if let Some(threshold) =
                                     log_retention_days.config_detail.get_threshold_int()
@@ -44,7 +44,7 @@ pub fn check_cloudwatch_log_group_retention<L: LineMarker>(
                                 }
                             }
                         } else {
-                            if !rule_config.enabled(RuleType::CW_002, &environment) {
+                            if !rule_config.enabled(RuleType::CW_002, environment) {
                                 continue;
                             }
                             error_reporter.add_error(

--- a/src/rules/aws/cloudwatch.rs
+++ b/src/rules/aws/cloudwatch.rs
@@ -10,6 +10,7 @@ pub fn check_cloudwatch_log_group_retention<L: LineMarker>(
     rule_config: &RuleConfig,
     error_reporter: &mut ErrorReporter,
     line_marker: &L,
+    environment: &str,
 ) {
     if let Some(cloudformation) = &infra_template.cloudformation {
         if let Some(resources) = &cloudformation.resources {
@@ -17,11 +18,11 @@ pub fn check_cloudwatch_log_group_retention<L: LineMarker>(
                 if let AWSResourceType::CloudWatch = &resource.type_ {
                     if let Some(properties) = &resource.properties {
                         if let Some(retention) = properties.get("RetentionInDays") {
-                            if !rule_config.enabled(RuleType::CW_001) {
+                            if !rule_config.enabled(RuleType::CW_001, &environment) {
                                 continue;
                             }
                             if let Some(log_retention_days) =
-                                rule_config.rules.get(&RuleType::CW_001)
+                                rule_config.get_rule(RuleType::CW_001, &environment)
                             {
                                 if let Some(threshold) =
                                     log_retention_days.config_detail.get_threshold_int()
@@ -43,7 +44,7 @@ pub fn check_cloudwatch_log_group_retention<L: LineMarker>(
                                 }
                             }
                         } else {
-                            if !rule_config.enabled(RuleType::CW_002) {
+                            if !rule_config.enabled(RuleType::CW_002, &environment) {
                                 continue;
                             }
                             error_reporter.add_error(

--- a/src/rules/aws/lambda.rs
+++ b/src/rules/aws/lambda.rs
@@ -198,6 +198,7 @@ pub fn check_lambda_powertools_environment_variables<L: LineMarker>(
     rule_config: &RuleConfig,
     error_reporter: &mut ErrorReporter,
     line_marker: &L,
+    environment: &str,
 ) {
     if let Some(cloudformation) = &infra_template.cloudformation {
         if let Some(resources) = &cloudformation.resources {
@@ -211,7 +212,9 @@ pub fn check_lambda_powertools_environment_variables<L: LineMarker>(
                         .and_then(|props| props.get("Environment"))
                         .and_then(|env| env.get("Variables"))
                     {
-                        if let Some(rule_type) = rule_config.rules.get(&RuleType::LAMBDA_005) {
+                        if let Some(rule_type) =
+                            rule_config.get_rule(RuleType::LAMBDA_005, &environment)
+                        {
                             if rule_type.enabled {
                                 if let Some(target_log_level) = rule_type.config_detail.get_value()
                                 {
@@ -239,7 +242,9 @@ pub fn check_lambda_powertools_environment_variables<L: LineMarker>(
                             }
                         }
 
-                        if let Some(rule_type) = rule_config.rules.get(&RuleType::LAMBDA_006) {
+                        if let Some(rule_type) =
+                            rule_config.get_rule(RuleType::LAMBDA_006, &environment)
+                        {
                             if rule_type.enabled {
                                 if let Some(powertools_logger_log_event) =
                                     variables.get("POWERTOOLS_LOGGER_LOG_EVENT")
@@ -262,10 +267,11 @@ pub fn check_lambda_powertools_environment_variables<L: LineMarker>(
                             }
                         }
 
-                        if let Some(rule_type) = rule_config.rules.get(&RuleType::LAMBDA_007) {
+                        if let Some(rule_type) =
+                            rule_config.get_rule(RuleType::LAMBDA_007, &environment)
+                        {
                             if rule_type.enabled {
                                 // Fetch threshold from the rule configuration
-                                dbg!(&rule_config.rules);
                                 let powertools_logger_sample_rate_config = rule_config
                                     .rules
                                     .get(&RuleType::LAMBDA_007)

--- a/src/rules/aws/lambda.rs
+++ b/src/rules/aws/lambda.rs
@@ -213,7 +213,7 @@ pub fn check_lambda_powertools_environment_variables<L: LineMarker>(
                         .and_then(|env| env.get("Variables"))
                     {
                         if let Some(rule_type) =
-                            rule_config.get_rule(RuleType::LAMBDA_005, &environment)
+                            rule_config.get_rule(RuleType::LAMBDA_005, environment)
                         {
                             if rule_type.enabled {
                                 if let Some(target_log_level) = rule_type.config_detail.get_value()
@@ -243,7 +243,7 @@ pub fn check_lambda_powertools_environment_variables<L: LineMarker>(
                         }
 
                         if let Some(rule_type) =
-                            rule_config.get_rule(RuleType::LAMBDA_006, &environment)
+                            rule_config.get_rule(RuleType::LAMBDA_006, environment)
                         {
                             if rule_type.enabled {
                                 if let Some(powertools_logger_log_event) =
@@ -268,7 +268,7 @@ pub fn check_lambda_powertools_environment_variables<L: LineMarker>(
                         }
 
                         if let Some(rule_type) =
-                            rule_config.get_rule(RuleType::LAMBDA_007, &environment)
+                            rule_config.get_rule(RuleType::LAMBDA_007, environment)
                         {
                             if rule_type.enabled {
                                 // Fetch threshold from the rule configuration


### PR DESCRIPTION
This pull request introduces several changes to support environment-specific rule configurations in the `Checker` and associated components. The main updates include adding an `environment` field to the `Checker` struct, modifying methods to pass the environment, and updating the configuration handling to support environments.

Key changes include:

### Environment Support in `Checker`:

* Added `environment` field to the `Checker` struct and updated its initialization in `src/checker.rs`. [[1]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faR12) [[2]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faR21-R58)
* Modified the `run_checks` method to pass the environment when enabling rules. [[1]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faR21-R58) [[2]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL64-R92)

### Configuration Updates:

* Added `environments` field to `RuleConfig` and updated the `enabled` method to check rules based on the environment in `src/parsers/config.rs`.
* Updated the default configuration to include a `default` environment and merged rules accordingly. [[1]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cR227-R233) [[2]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cL235-R257)

### Test Adjustments:

* Updated tests to handle environment-specific rule configurations and added new tests for default environments in `src/parsers/config.rs`. [[1]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cL260-R309) [[2]](diffhunk://#diff-8fa62ea0194bdcba5a73559067034668f6e596f94f695dc5a47a855c2011241cR391-R400)
* Modified test fixtures and test functions to pass the environment parameter in `src/checker.rs` and `src/parsers/cfn.rs`. [[1]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faR170-R173) [[2]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL176-R187) [[3]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faL190-R207) [[4]](diffhunk://#diff-80d406c60c48b139f4acbeb1b43605d26970cf1de2e39e423ebcf701051e63faR244) [[5]](diffhunk://#diff-633174531c165664702c2add326aa45712314bb31988ebb73b45e6328c12fd20L460-R460)

### Command-line Argument Changes:

* Changed the `environment` argument to have a default value of "default" in `src/main.rs`. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL22-R23) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL47-R63)

### Rule Check Modifications:

* Updated rule check functions to accept and use the environment parameter in `src/rules/aws/cloudwatch.rs` and `src/rules/aws/lambda.rs`. [[1]](diffhunk://#diff-13e28caeadb499fcd8235e6c822e6843cf8e78a90833ef7846e134f6d5d7671aR13-R25) [[2]](diffhunk://#diff-13e28caeadb499fcd8235e6c822e6843cf8e78a90833ef7846e134f6d5d7671aL46-R47) [[3]](diffhunk://#diff-bf9440640da19007a141da5950f2f200b422056bd2a1299ae668b9906e69f899R201)