### PR TITLE
Add Lambda 008 and 009

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,15 +91,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "ccs"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "dialoguer",
  "indexmap",
  "marked-yaml",
  "regex",
  "rstest",
  "serde",
+ "serde_json",
  "serde_yaml",
  "strum",
  "strum_macros",
@@ -159,10 +167,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -178,6 +218,22 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "futures"
@@ -275,6 +331,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +412,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "libc"
+version = "0.2.178"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "marked-yaml"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +484,12 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regex"
@@ -480,6 +566,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +617,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +649,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "slab"
@@ -588,6 +705,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +778,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +800,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "windows-sys"
@@ -728,6 +893,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
 name = "yaml-rust2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,3 +928,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ strum_macros = "0.26.4"
 indexmap = { version = "2.7.0", features = ["serde"] }
 toml = "0.8.19"
 regex = "1.5.4"
+dialoguer = "0.11"
+serde_json = "1.0"
 
 [dev-dependencies]
 rstest = "0.23.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,9 @@ RUN apt-get update && apt-get install -y \
 # Build the project
 RUN cargo build --release
 
-# Set the entrypoint to the built binary
-ENTRYPOINT ["/usr/src/app/target/release/ccs"]
+# Copy the entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Set the entrypoint to the script
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ Add the following step to your workflow YAML (e.g., `.github/workflows/cloud_cos
     environment: default
     samconfig: src/fixtures/aws/samconfig.toml
     config: src/fixtures/cloudsaving.yaml
-    cloud_provider: aws
 ```
 
 ### Inputs
@@ -197,6 +196,8 @@ Add the following step to your workflow YAML (e.g., `.github/workflows/cloud_cos
 | environment    | Environment name for rule overrides (from config)        | No       | default                                      |
 | samconfig      | Path to your AWS SAM config file                         | No       | src/fixtures/aws/samconfig.toml               |
 | config         | Path to the Cloud Cost Saver configuration file          | No       | src/fixtures/cloudsaving.yaml                 |
+| preset         | Configuration preset (minimal, recommended, strict)      | No       | recommended                                  |
+| format         | Output format (text, json)                               | No       | text                                         |
 
 ### Example Workflow
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,33 @@ cd cloud-cost-saver
 
 ## Usage
 
-To analyze a CloudFormation template, use the following command:
+### interactive Initialization (New)
+To quickly set up a configuration file, use the `init` command:
 
 ```sh
-cargo run -- --template src/fixtures/aws/cfn-testing.yaml --environment default --samconfig src/fixtures/aws/samconfig.toml --config cloudsaving.yaml
+cargo run -- init
+```
+
+### Scan a Template
+To analyze a CloudFormation template, use the `scan` command:
+
+```sh
+cargo run -- scan --template src/fixtures/aws/cfn-testing.yaml --environment default --samconfig src/fixtures/aws/samconfig.toml --config cloudsaving.yaml
+```
+
+You can also output the results in JSON format:
+
+```sh
+cargo run -- scan --template src/fixtures/aws/cfn-testing.yaml --format json
+```
+
+
+
+### Configuration Presets
+You can apply `minimal`, `recommended`, or `strict` rule sets using the `--preset` flag:
+
+```sh
+cargo run -- scan --template src/fixtures/aws/cfn-testing.yaml --preset strict
 ```
 
 ## Example Output
@@ -59,6 +82,8 @@ This section lists the various violations that this tool can detect in AWS Cloud
 | LAMBDA-005 | Set the POWERTOOLS_LOG_LEVEL environment variable to appropriate logging levels for different environments when using AWS Lambda Powertools. This helps in reducing logging costs. | false |
 | LAMBDA-006 | Logging every incoming event may significantly increase cloud costs. Consider disabling POWERTOOLS_LOGGER_LOG_EVENT in the production environment to help reduce logging expenses. | true |
 | LAMBDA-007 | Set the POWERTOOLS_LOGGER_SAMPLE_RATE environment variable to a value between 0 and 1 to sample logs and reduce logging costs when using AWS Lambda Powertools. | false |
+| LAMBDA-008 | Ensure Lambda functions in a VPC have compatible Gateway Endpoints (S3/DynamoDB) to avoid expensive NAT Gateway data processing charges. | true |
+| LAMBDA-009 | Detect Static Provisioned Concurrency without AutoScaling. Suggests using Application Auto Scaling to optimize costs during low-traffic periods. | true |
 
 #### CloudWatch
 
@@ -138,6 +163,8 @@ The `cloudsaving.yaml` file allows you to customize the behavior of the Cloud Co
 | LAMBDA_005 | Value              | POWERTOOLS_LOG_LEVEL value |
 | LAMBDA_006 | Simple             | Enable to check if POWERTOOLS_LOGGER_LOG_EVENT is set to false |
 | LAMBDA_007 | Threshold          | Set sample rate with POWERTOOLS_LOGGER_SAMPLE_RATE |
+| LAMBDA_008 | Simple             | Enabled or not |
+| LAMBDA_009 | Simple             | Enabled or not |
 | CW_001     | Threshold          | Log retention period in days |
 | CW_002     | Simple             | Enabled or not |
 | CW_003     | Simple             | Enabled or not |

--- a/action.yml
+++ b/action.yml
@@ -15,16 +15,14 @@ inputs:
   config:
     description: "Path to the Cloud Cost Saver configuration file"
     required: true
-    default: "./cloudsaving.yaml"
+  preset:
+    description: "Configuration preset (minimal, recommended, strict)"
+    required: false
+  format:
+    description: "Output format (text, json)"
+    required: false
+    default: "text"
 runs:
   using: "docker"
   image: "Dockerfile"
-  args:
-    - "--template"
-    - "${{ inputs.template }}"
-    - "--environment"
-    - "${{ inputs.environment }}"
-    - "--samconfig"
-    - "${{ inputs.samconfig }}"
-    - "--config"
-    - "${{ inputs.config }}"
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+# Start building the command
+CMD="/usr/src/app/target/release/ccs scan"
+
+# Required arguments
+if [ -n "$INPUT_TEMPLATE" ]; then
+  CMD="$CMD --template $INPUT_TEMPLATE"
+fi
+
+if [ -n "$INPUT_CONFIG" ]; then
+  CMD="$CMD --config $INPUT_CONFIG"
+fi
+
+# Optional arguments
+if [ -n "$INPUT_ENVIRONMENT" ]; then
+  CMD="$CMD --environment $INPUT_ENVIRONMENT"
+fi
+
+if [ -n "$INPUT_SAMCONFIG" ]; then
+  CMD="$CMD --samconfig $INPUT_SAMCONFIG"
+fi
+
+if [ -n "$INPUT_PRESET" ]; then
+  CMD="$CMD --preset $INPUT_PRESET"
+fi
+
+if [ -n "$INPUT_FORMAT" ]; then
+  CMD="$CMD --format $INPUT_FORMAT"
+fi
+
+# Execute the constructed command
+echo "Running: $CMD"
+exec $CMD

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -97,6 +97,24 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
                 self.line_marker,
             );
         }
+
+
+
+        if rule_config.enabled(RuleType::LAMBDA_008, self.environment) {
+            aws::lambda::check_lambda_vpc_gateway_endpoints(
+                self.cloudformation,
+                self.error_reporter,
+                self.line_marker,
+            );
+        }
+
+        if rule_config.enabled(RuleType::LAMBDA_009, self.environment) {
+            aws::lambda::check_lambda_provisioned_concurrency_autoscaling(
+                self.cloudformation,
+                self.error_reporter,
+                self.line_marker,
+            );
+        }
     }
 }
 
@@ -396,5 +414,104 @@ mod tests_cfn {
             ]);
             expected.assert_all_match(&context.error_reporter.render_errors());
         }
+
+
+
+        #[rstest]
+        #[case(
+            "cfn-advanced-cost.yaml",
+            RuleType::LAMBDA_008,
+            None,
+            LambdaViolation::NoVPCGatewayEndpoint
+        )]
+        fn test_lambda_008(
+            #[case] template_name: &str,
+            #[case] rule_type: RuleType,
+            #[case] config_detail: Option<RuleTypeConfigDetail>,
+            #[case] violation: LambdaViolation,
+            setup_checker: impl Fn(&str, RuleType, Option<RuleTypeConfigDetail>) -> TestContext,
+        ) {
+            let mut context = setup_checker(template_name, rule_type, config_detail);
+            let mut checker = context.create_checker();
+            checker.run_checks();
+
+            let expected = ExpectedViolations::new(vec![ExpectedViolation::new(
+                &violation,
+                "MyVPCLambda",
+            )]);
+            expected.assert_all_match(&context.error_reporter.render_errors());
+        }
+
+        #[rstest]
+        #[case(
+            "cfn-advanced-cost.yaml",
+            RuleType::LAMBDA_009,
+            None,
+            LambdaViolation::StaticProvisionedConcurrencyWithoutAutoScaling
+        )]
+        fn test_lambda_009(
+            #[case] template_name: &str,
+            #[case] rule_type: RuleType,
+            #[case] config_detail: Option<RuleTypeConfigDetail>,
+            #[case] violation: LambdaViolation,
+            setup_checker: impl Fn(&str, RuleType, Option<RuleTypeConfigDetail>) -> TestContext,
+        ) {
+            let mut context = setup_checker(template_name, rule_type, config_detail);
+            let mut checker = context.create_checker();
+            checker.run_checks();
+
+            let expected = ExpectedViolations::new(vec![
+                ExpectedViolation::new(&violation, "MyStaticConcurrencyLambda"),
+                ExpectedViolation::new(&violation, "MyStaticServerless"),
+            ]);
+            expected.assert_all_match(&context.error_reporter.render_errors());
+        }
+
+        #[rstest]
+        #[case("cfn-advanced-cost.yaml", crate::parsers::config::Preset::Minimal)]
+        fn test_preset_minimal(
+            #[case] template_name: &str,
+            #[case] preset: crate::parsers::config::Preset,
+            setup_checker: impl Fn(&str, RuleType, Option<RuleTypeConfigDetail>) -> TestContext,
+        ) {
+            // Need a slight variance of setup_checker to apply preset
+            let mut context = setup_checker(template_name, RuleType::LAMBDA_001, None); 
+            // Apply preset to config manually since setup_checker is rigid
+            context.config.cloudformation.apply_preset(preset);
+            
+            let mut checker = context.create_checker();
+            checker.run_checks();
+
+            // Minimal should NOT catch Missing Tags (LAMBDA-003) or Event Filtering (LAMBDA-008)
+            // It SHOULD catch Static Concurrency (LAMBDA-009)
+            let errors = context.error_reporter.render_errors();
+            
+            assert!(!errors.contains("LAMBDA-003"));
+            assert!(errors.contains("LAMBDA-009"));
+        }
+
+        #[rstest]
+        #[case("cfn-advanced-cost.yaml", crate::parsers::config::Preset::Strict)]
+        fn test_preset_strict(
+            #[case] template_name: &str,
+            #[case] preset: crate::parsers::config::Preset,
+            setup_checker: impl Fn(&str, RuleType, Option<RuleTypeConfigDetail>) -> TestContext,
+        ) {
+            let mut context = setup_checker(template_name, RuleType::LAMBDA_001, None);
+            context.config.cloudformation.apply_preset(preset);
+            
+            let mut checker = context.create_checker();
+            checker.run_checks();
+
+            // Strict SHOULD catch Missing Tags (LAMBDA-003), Filtering (LAMBDA-008), and Concurrency (LAMBDA-009)
+            let errors = context.error_reporter.render_errors();
+
+            // Note: LAMBDA-003 requires configuration of values normally, but Strict preset provides default "CostCenter"
+            // MyUntaggedLambda has NO tags, so it should fail if rule is enabled checking for "CostCenter"
+            assert!(errors.contains("LAMBDA-003"));
+            assert!(errors.contains("LAMBDA-009"));
+        }
     }
 }
+
+

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -98,8 +98,6 @@ impl<'a, L: LineMarker + 'a> Checker<'a, L> {
             );
         }
 
-
-
         if rule_config.enabled(RuleType::LAMBDA_008, self.environment) {
             aws::lambda::check_lambda_vpc_gateway_endpoints(
                 self.cloudformation,
@@ -415,8 +413,6 @@ mod tests_cfn {
             expected.assert_all_match(&context.error_reporter.render_errors());
         }
 
-
-
         #[rstest]
         #[case(
             "cfn-advanced-cost.yaml",
@@ -435,10 +431,8 @@ mod tests_cfn {
             let mut checker = context.create_checker();
             checker.run_checks();
 
-            let expected = ExpectedViolations::new(vec![ExpectedViolation::new(
-                &violation,
-                "MyVPCLambda",
-            )]);
+            let expected =
+                ExpectedViolations::new(vec![ExpectedViolation::new(&violation, "MyVPCLambda")]);
             expected.assert_all_match(&context.error_reporter.render_errors());
         }
 
@@ -475,17 +469,17 @@ mod tests_cfn {
             setup_checker: impl Fn(&str, RuleType, Option<RuleTypeConfigDetail>) -> TestContext,
         ) {
             // Need a slight variance of setup_checker to apply preset
-            let mut context = setup_checker(template_name, RuleType::LAMBDA_001, None); 
+            let mut context = setup_checker(template_name, RuleType::LAMBDA_001, None);
             // Apply preset to config manually since setup_checker is rigid
             context.config.cloudformation.apply_preset(preset);
-            
+
             let mut checker = context.create_checker();
             checker.run_checks();
 
             // Minimal should NOT catch Missing Tags (LAMBDA-003) or Event Filtering (LAMBDA-008)
             // It SHOULD catch Static Concurrency (LAMBDA-009)
             let errors = context.error_reporter.render_errors();
-            
+
             assert!(!errors.contains("LAMBDA-003"));
             assert!(errors.contains("LAMBDA-009"));
         }
@@ -499,7 +493,7 @@ mod tests_cfn {
         ) {
             let mut context = setup_checker(template_name, RuleType::LAMBDA_001, None);
             context.config.cloudformation.apply_preset(preset);
-            
+
             let mut checker = context.create_checker();
             checker.run_checks();
 
@@ -513,5 +507,3 @@ mod tests_cfn {
         }
     }
 }
-
-

--- a/src/error_reporter.rs
+++ b/src/error_reporter.rs
@@ -68,4 +68,34 @@ impl ErrorReporter {
             .collect::<Vec<String>>()
             .join("\n")
     }
+
+    pub fn render_json(&self) -> String {
+        use serde::Serialize;
+
+        #[derive(Serialize)]
+        struct JsonErrorDetail {
+            code: String,
+            message: String,
+            resource: String,
+            file: String,
+            line: Option<usize>,
+        }
+
+        let json_errors: Vec<JsonErrorDetail> = self
+            .errors
+            .iter()
+            .map(|e| {
+                let line = e.span.as_ref().and_then(|s| s.start()).map(|p| p.line() - 1);
+                JsonErrorDetail {
+                    code: e.violation.code(),
+                    message: e.violation.message(),
+                    resource: e.resource_name.clone(),
+                    file: self.file_path.clone(),
+                    line,
+                }
+            })
+            .collect();
+
+        serde_json::to_string_pretty(&json_errors).unwrap_or_else(|_| "[]".to_string())
+    }
 }

--- a/src/error_reporter.rs
+++ b/src/error_reporter.rs
@@ -85,7 +85,11 @@ impl ErrorReporter {
             .errors
             .iter()
             .map(|e| {
-                let line = e.span.as_ref().and_then(|s| s.start()).map(|p| p.line() - 1);
+                let line = e
+                    .span
+                    .as_ref()
+                    .and_then(|s| s.start())
+                    .map(|p| p.line() - 1);
                 JsonErrorDetail {
                     code: e.violation.code(),
                     message: e.violation.message(),

--- a/src/fixtures/aws/cfn-advanced-cost.yaml
+++ b/src/fixtures/aws/cfn-advanced-cost.yaml
@@ -1,0 +1,86 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Template for testing advanced Lambda cost rules
+
+Resources:
+  # ----------------------------------------------------------
+  #  Storage & Data Transfer (VPC Endpoints)
+  # ----------------------------------------------------------
+  
+  # Violation: Lambda in VPC, but no Gateway Endpoints found in template
+  # (Note: This is now a Warning, not Error)
+  MyVPCLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: arn:aws:iam::123456789012:role/service-role/role
+      Runtime: nodejs18.x
+      Code:
+        ZipFile: "foo"
+      VpcConfig:
+        SecurityGroupIds:
+          - sg-085912345678492fb
+        SubnetIds:
+          - subnet-071f712345678e7c8
+          - subnet-071f712345678e7c9
+
+  # ----------------------------------------------------------
+  #  Provisioned Concurrency Scheduling
+  # ----------------------------------------------------------
+  
+  # Violation: Static Provisioned Concurrency > 0 with NO AutoScaling
+  MyStaticConcurrencyLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: arn:aws:iam::123456789012:role/service-role/role
+      Runtime: nodejs18.x
+      Code:
+        ZipFile: "foo"
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 10
+  
+  # Violation: Serverless Function with Static Provisioned Concurrency and no Scaling
+  MyStaticServerless:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs18.x
+      CodeUri: s3://bucket/key
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 5
+
+  # Compliant: Provisioned Concurrency WITH AutoScaling
+  MyScaledLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: arn:aws:iam::123456789012:role/service-role/role
+      Runtime: nodejs18.x
+      Code:
+        ZipFile: "foo"
+      ProvisionedConcurrencyConfig:
+        ProvisionedConcurrentExecutions: 10
+  
+  MyScaledLambdaTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: 100
+      MinCapacity: 1
+      ResourceId: !Sub function:${MyScaledLambda}:provisioned
+      RoleARN: arn:aws:iam::123456789012:role/service-role/role
+      ScalableDimension: lambda:function:ProvisionedConcurrency
+      ServiceNamespace: lambda
+  
+  # ----------------------------------------------------------
+  # NEW: Preset verification resource
+  # ----------------------------------------------------------
+  # Violation: Missing Tag (Only detected in STRICT mode)
+  MyUntaggedLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+       Handler: index.handler
+       Role: arn:aws:iam::123456789012:role/service-role/role
+       Runtime: nodejs18.x
+       Code:
+         ZipFile: "foo"

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod error_reporter;
 mod parsers;
 mod rules;
 use crate::parsers::cfn::{parse_cloudformation, parse_samconfig};
-use clap::{Parser, Subcommand, CommandFactory};
+use clap::{CommandFactory, Parser, Subcommand};
 use dialoguer::Confirm;
 use std::fs;
 
@@ -75,15 +75,19 @@ fn run_init() -> ExitCode {
         .default(false)
         .interact()
         .unwrap();
-    
+
     // We can now use presets for init too!
-    let preset = if strict_mode { Some(crate::parsers::config::Preset::Strict) } else { Some(crate::parsers::config::Preset::Recommended) };
+    let preset = if strict_mode {
+        Some(crate::parsers::config::Preset::Strict)
+    } else {
+        Some(crate::parsers::config::Preset::Recommended)
+    };
 
     let mut rule_config = RuleConfig::default();
     if let Some(p) = preset {
         rule_config.apply_preset(p);
     }
-    
+
     // Default environment always created with empty overrides (inherits base rules)
     rule_config.environments.insert("default".to_string(), None);
 
@@ -111,12 +115,12 @@ fn run_scan(args: ScanArgs) -> ExitCode {
         eprintln!("Failed to load config: {e}");
         std::process::exit(1);
     });
-    
+
     // CLI override for preset
     if let Some(preset) = args.preset {
         config.cloudformation.apply_preset(preset);
     }
-    
+
     let environment = args.environment;
     let mut error_reporter = error_reporter::ErrorReporter::new(&template_file);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,18 +3,35 @@ mod checker;
 use std::process::ExitCode;
 
 use crate::checker::Checker;
-use crate::parsers::config::Config;
+use crate::parsers::config::{Config, RuleConfig};
 mod error_reporter;
 mod parsers;
 mod rules;
 use crate::parsers::cfn::{parse_cloudformation, parse_samconfig};
-use clap::Parser;
+use clap::{Parser, Subcommand, CommandFactory};
+use dialoguer::Confirm;
+use std::fs;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    #[clap(flatten)]
+    scan_args: ScanArgs,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    Init,
+    Scan(ScanArgs),
+}
+
+#[derive(clap::Args, Debug, Clone)]
+struct ScanArgs {
     #[arg(short, long)]
-    template: String,
+    template: Option<String>,
 
     #[arg(short, long, default_value = "default")]
     environment: String,
@@ -24,17 +41,82 @@ struct Args {
 
     #[arg(short, long, default_value_t = String::from("./cloudsaving.yaml"))]
     config: String,
+
+    #[arg(long, default_value = "text")]
+    format: String,
+
+    #[arg(short, long)]
+    preset: Option<crate::parsers::config::Preset>,
 }
 
 fn main() -> ExitCode {
     let args = Args::parse();
 
-    let template_file = args.template;
+    match args.command {
+        Some(Commands::Init) => run_init(),
+        Some(Commands::Scan(scan_args)) => run_scan(scan_args),
+        None => {
+            let _ = Args::command().print_help();
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run_init() -> ExitCode {
+    println!("Welcome to CloudSaver initialization!");
+
+    let env_name: String = dialoguer::Input::new()
+        .with_prompt("Enter the name of your environment (e.g. production)")
+        .interact()
+        .unwrap();
+
+    let strict_mode = Confirm::new()
+        .with_prompt("Enable strict mode? (Enables all rules)")
+        .default(false)
+        .interact()
+        .unwrap();
+    
+    // We can now use presets for init too!
+    let preset = if strict_mode { Some(crate::parsers::config::Preset::Strict) } else { Some(crate::parsers::config::Preset::Recommended) };
+
+    let mut rule_config = RuleConfig::default();
+    if let Some(p) = preset {
+        rule_config.apply_preset(p);
+    }
+    
+    // Default environment always created with empty overrides (inherits base rules)
+    rule_config.environments.insert("default".to_string(), None);
+
+    // User environment created with empty overrides (inherits base rules)
+    // Avoid cloning full rule set
+    if env_name != "default" {
+        rule_config.environments.insert(env_name, None);
+    }
+
+    let config = Config {
+        cloudformation: rule_config,
+    };
+
+    let yaml_string = serde_yaml::to_string(&config).expect("Failed to serialize config");
+    fs::write("cloudsaving.yaml", yaml_string).expect("Failed to write config file");
+
+    println!("Configuration saved to cloudsaving.yaml");
+    ExitCode::SUCCESS
+}
+
+fn run_scan(args: ScanArgs) -> ExitCode {
+    let template_file = args.template.expect("Template file is required for scan");
     let config_file = args.config;
-    let config = Config::load(&config_file).unwrap_or_else(|e| {
+    let mut config = Config::load(&config_file).unwrap_or_else(|e| {
         eprintln!("Failed to load config: {e}");
         std::process::exit(1);
     });
+    
+    // CLI override for preset
+    if let Some(preset) = args.preset {
+        config.cloudformation.apply_preset(preset);
+    }
+    
     let environment = args.environment;
     let mut error_reporter = error_reporter::ErrorReporter::new(&template_file);
 
@@ -57,7 +139,11 @@ fn main() -> ExitCode {
     );
     checker.run_checks();
     if error_reporter.has_errors() {
-        eprintln!("{}", error_reporter.render_errors());
+        if args.format == "json" {
+            println!("{}", error_reporter.render_json());
+        } else {
+            eprintln!("{}", error_reporter.render_errors());
+        }
         return ExitCode::FAILURE;
     }
 

--- a/src/parsers/cfn.rs
+++ b/src/parsers/cfn.rs
@@ -285,7 +285,9 @@ impl<'de> Deserialize<'de> for AWSResourceType {
             "AWS::LAMBDA::FUNCTION" => Self::LambdaFunction,
             "AWS::SERVERLESS::FUNCTION" => Self::LambdaServerlessFunction,
             "AWS::EC2::VPCENDPOINT" => Self::EC2VPCEndpoint,
-            "AWS::APPLICATIONAUTOSCALING::SCALABLETARGET" => Self::ApplicationAutoScalingScalableTarget,
+            "AWS::APPLICATIONAUTOSCALING::SCALABLETARGET" => {
+                Self::ApplicationAutoScalingScalableTarget
+            }
             "AWS::LOGS::LOGGROUP" => Self::CloudWatch,
             _ => Self::Unknown(cfn_type),
         };

--- a/src/parsers/cfn.rs
+++ b/src/parsers/cfn.rs
@@ -269,6 +269,8 @@ pub struct Resource {
 pub enum AWSResourceType {
     LambdaFunction,
     LambdaServerlessFunction,
+    EC2VPCEndpoint,
+    ApplicationAutoScalingScalableTarget,
     CloudWatch,
     Unknown(String),
 }
@@ -282,6 +284,8 @@ impl<'de> Deserialize<'de> for AWSResourceType {
         let resource_type = match cfn_type.to_uppercase().as_str() {
             "AWS::LAMBDA::FUNCTION" => Self::LambdaFunction,
             "AWS::SERVERLESS::FUNCTION" => Self::LambdaServerlessFunction,
+            "AWS::EC2::VPCENDPOINT" => Self::EC2VPCEndpoint,
+            "AWS::APPLICATIONAUTOSCALING::SCALABLETARGET" => Self::ApplicationAutoScalingScalableTarget,
             "AWS::LOGS::LOGGROUP" => Self::CloudWatch,
             _ => Self::Unknown(cfn_type),
         };

--- a/src/parsers/config.rs
+++ b/src/parsers/config.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
+use serde::ser::SerializeMap;
 use std::collections::HashMap;
 use std::fs;
 use std::hash::Hash;
@@ -10,13 +11,14 @@ pub struct RuleTypeConfig {
     pub config_detail: RuleTypeConfigDetail,
 }
 
-#[derive(Debug, Serialize, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(untagged)]
 pub enum ThresholdValue {
     Int(u64),
     Float(f64),
 }
 
-#[derive(Debug, Serialize, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum RuleTypeConfigDetail {
     Value { value: String },
     Values { values: Vec<String> },
@@ -58,6 +60,35 @@ impl<'de> Deserialize<'de> for RuleTypeConfigDetail {
         }
 
         Ok(RuleTypeConfigDetail::Simple)
+    }
+}
+
+impl Serialize for RuleTypeConfigDetail {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            RuleTypeConfigDetail::Simple => {
+                let map = serializer.serialize_map(Some(0))?;
+                map.end()
+            }
+            RuleTypeConfigDetail::Value { value } => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("value", value)?;
+                map.end()
+            }
+            RuleTypeConfigDetail::Values { values } => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("values", values)?;
+                map.end()
+            }
+            RuleTypeConfigDetail::Threshold { threshold } => {
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("threshold", threshold)?;
+                map.end()
+            }
+        }
     }
 }
 
@@ -109,15 +140,30 @@ pub enum RuleType {
     LAMBDA_005,
     LAMBDA_006,
     LAMBDA_007,
+
+    LAMBDA_008,
+    LAMBDA_009,
     CW_001,
     CW_002,
     CW_003,
 }
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum Preset {
+    Minimal,
+    Recommended,
+    Strict,
+}
+
+
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RuleConfig {
     pub rules: HashMap<RuleType, RuleTypeConfig>,
     pub environments: HashMap<String, Option<HashMap<RuleType, RuleTypeConfig>>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preset: Option<Preset>,
 }
 
 impl RuleConfig {
@@ -139,7 +185,96 @@ impl RuleConfig {
             .and_then(|rules| rules.as_ref())
             .and_then(|rules| rules.get(&rule))
     }
+
+    pub fn apply_preset(&mut self, preset: Preset) {
+        self.preset = Some(preset);
+        let mut new_rules = HashMap::new();
+
+
+        // Helper to enable a rule simply
+        let enable = |enabled: bool| RuleTypeConfig {
+            enabled,
+            config_detail: RuleTypeConfigDetail::Simple,
+        };
+
+        match preset {
+            Preset::Minimal => {
+                // Critical only
+                new_rules.insert(RuleType::LAMBDA_001, enable(true)); // Log retention missing
+                new_rules.insert(RuleType::LAMBDA_004, RuleTypeConfig { // Async retries
+                    enabled: true,
+                    config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(0) },
+                });
+                new_rules.insert(RuleType::LAMBDA_009, enable(true)); // Static concurrency
+                new_rules.insert(RuleType::CW_002, enable(true)); // No retention policy
+                
+                // Explicitly disable others commonly on by default
+                new_rules.insert(RuleType::LAMBDA_006, enable(false));
+                new_rules.insert(RuleType::LAMBDA_008, enable(false));
+                new_rules.insert(RuleType::CW_001, RuleTypeConfig {
+                     enabled: false,
+                     config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(30) },
+                });
+            }
+            Preset::Recommended => {
+                // Minimal + High Value rules (Default-ish)
+                new_rules.insert(RuleType::LAMBDA_001, enable(true));
+                new_rules.insert(RuleType::LAMBDA_004, RuleTypeConfig {
+                    enabled: true,
+                    config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(0) },
+                });
+                new_rules.insert(RuleType::LAMBDA_006, enable(true));
+                new_rules.insert(RuleType::LAMBDA_008, enable(true));
+                new_rules.insert(RuleType::LAMBDA_009, enable(true));
+                new_rules.insert(RuleType::CW_001, RuleTypeConfig {
+                     enabled: true,
+                     config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(30) },
+                });
+                new_rules.insert(RuleType::CW_002, enable(true));
+            }
+            Preset::Strict => {
+                // Everything enabled
+                new_rules.insert(RuleType::LAMBDA_001, enable(true));
+                new_rules.insert(RuleType::LAMBDA_002, enable(true)); // ARM
+                new_rules.insert(RuleType::LAMBDA_003, RuleTypeConfig { // Tags
+                    enabled: true,
+                    config_detail: RuleTypeConfigDetail::Values { values: vec!["CostCenter".to_string()] },
+                });
+                new_rules.insert(RuleType::LAMBDA_004, RuleTypeConfig {
+                    enabled: true,
+                    config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(0) },
+                });
+                new_rules.insert(RuleType::LAMBDA_005, RuleTypeConfig {
+                    enabled: true,
+                    config_detail: RuleTypeConfigDetail::Value { value: "INFO".to_string() },
+                });
+                new_rules.insert(RuleType::LAMBDA_006, enable(true));
+                new_rules.insert(RuleType::LAMBDA_007, RuleTypeConfig {
+                     enabled: true,
+                     config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Float(0.1) },
+                });
+                new_rules.insert(RuleType::LAMBDA_008, enable(true));
+                new_rules.insert(RuleType::LAMBDA_009, enable(true));
+                new_rules.insert(RuleType::CW_001, RuleTypeConfig {
+                     enabled: true,
+                     config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(14) },
+                });
+                new_rules.insert(RuleType::CW_002, enable(true));
+                new_rules.insert(RuleType::CW_003, enable(true));
+            }
+        }
+
+        // Apply new rules, merging with existing ones
+        for (key, val) in new_rules {
+            self.rules.insert(key.clone(), val.clone());
+            // Also update all environments to ensure consistency
+            for env_rules in self.environments.values_mut().flatten() {
+                env_rules.insert(key.clone(), val.clone());
+            }
+        }
+    }
 }
+
 
 impl Default for RuleConfig {
     fn default() -> Self {
@@ -201,6 +336,21 @@ impl Default for RuleConfig {
                 },
             },
         );
+
+        rules.insert(
+            RuleType::LAMBDA_008,
+            RuleTypeConfig {
+                enabled: true,
+                config_detail: RuleTypeConfigDetail::Simple,
+            },
+        );
+        rules.insert(
+            RuleType::LAMBDA_009,
+            RuleTypeConfig {
+                enabled: true,
+                config_detail: RuleTypeConfigDetail::Simple,
+            },
+        );
         rules.insert(
             RuleType::CW_001,
             RuleTypeConfig {
@@ -230,6 +380,7 @@ impl Default for RuleConfig {
         RuleConfig {
             rules,
             environments,
+            preset: None,
         }
     }
 }
@@ -252,6 +403,11 @@ impl Config {
                 .rules
                 .entry(rule_name)
                 .or_insert(default_rule);
+        }
+
+        // Apply preset if defined in config
+        if let Some(preset) = config.cloudformation.preset {
+            config.cloudformation.apply_preset(preset);
         }
 
         // Create `default` environment

--- a/src/parsers/config.rs
+++ b/src/parsers/config.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize, Serializer};
 use serde::ser::SerializeMap;
+use serde::{Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
 use std::fs;
 use std::hash::Hash;
@@ -156,8 +156,6 @@ pub enum Preset {
     Strict,
 }
 
-
-
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RuleConfig {
     pub rules: HashMap<RuleType, RuleTypeConfig>,
@@ -190,7 +188,6 @@ impl RuleConfig {
         self.preset = Some(preset);
         let mut new_rules = HashMap::new();
 
-
         // Helper to enable a rule simply
         let enable = |enabled: bool| RuleTypeConfig {
             enabled,
@@ -201,64 +198,111 @@ impl RuleConfig {
             Preset::Minimal => {
                 // Critical only
                 new_rules.insert(RuleType::LAMBDA_001, enable(true)); // Log retention missing
-                new_rules.insert(RuleType::LAMBDA_004, RuleTypeConfig { // Async retries
-                    enabled: true,
-                    config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(0) },
-                });
+                new_rules.insert(
+                    RuleType::LAMBDA_004,
+                    RuleTypeConfig {
+                        // Async retries
+                        enabled: true,
+                        config_detail: RuleTypeConfigDetail::Threshold {
+                            threshold: ThresholdValue::Int(0),
+                        },
+                    },
+                );
                 new_rules.insert(RuleType::LAMBDA_009, enable(true)); // Static concurrency
                 new_rules.insert(RuleType::CW_002, enable(true)); // No retention policy
-                
+
                 // Explicitly disable others commonly on by default
                 new_rules.insert(RuleType::LAMBDA_006, enable(false));
                 new_rules.insert(RuleType::LAMBDA_008, enable(false));
-                new_rules.insert(RuleType::CW_001, RuleTypeConfig {
-                     enabled: false,
-                     config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(30) },
-                });
+                new_rules.insert(
+                    RuleType::CW_001,
+                    RuleTypeConfig {
+                        enabled: false,
+                        config_detail: RuleTypeConfigDetail::Threshold {
+                            threshold: ThresholdValue::Int(30),
+                        },
+                    },
+                );
             }
             Preset::Recommended => {
                 // Minimal + High Value rules (Default-ish)
                 new_rules.insert(RuleType::LAMBDA_001, enable(true));
-                new_rules.insert(RuleType::LAMBDA_004, RuleTypeConfig {
-                    enabled: true,
-                    config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(0) },
-                });
+                new_rules.insert(
+                    RuleType::LAMBDA_004,
+                    RuleTypeConfig {
+                        enabled: true,
+                        config_detail: RuleTypeConfigDetail::Threshold {
+                            threshold: ThresholdValue::Int(0),
+                        },
+                    },
+                );
                 new_rules.insert(RuleType::LAMBDA_006, enable(true));
                 new_rules.insert(RuleType::LAMBDA_008, enable(true));
                 new_rules.insert(RuleType::LAMBDA_009, enable(true));
-                new_rules.insert(RuleType::CW_001, RuleTypeConfig {
-                     enabled: true,
-                     config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(30) },
-                });
+                new_rules.insert(
+                    RuleType::CW_001,
+                    RuleTypeConfig {
+                        enabled: true,
+                        config_detail: RuleTypeConfigDetail::Threshold {
+                            threshold: ThresholdValue::Int(30),
+                        },
+                    },
+                );
                 new_rules.insert(RuleType::CW_002, enable(true));
             }
             Preset::Strict => {
                 // Everything enabled
                 new_rules.insert(RuleType::LAMBDA_001, enable(true));
                 new_rules.insert(RuleType::LAMBDA_002, enable(true)); // ARM
-                new_rules.insert(RuleType::LAMBDA_003, RuleTypeConfig { // Tags
-                    enabled: true,
-                    config_detail: RuleTypeConfigDetail::Values { values: vec!["CostCenter".to_string()] },
-                });
-                new_rules.insert(RuleType::LAMBDA_004, RuleTypeConfig {
-                    enabled: true,
-                    config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(0) },
-                });
-                new_rules.insert(RuleType::LAMBDA_005, RuleTypeConfig {
-                    enabled: true,
-                    config_detail: RuleTypeConfigDetail::Value { value: "INFO".to_string() },
-                });
+                new_rules.insert(
+                    RuleType::LAMBDA_003,
+                    RuleTypeConfig {
+                        // Tags
+                        enabled: true,
+                        config_detail: RuleTypeConfigDetail::Values {
+                            values: vec!["CostCenter".to_string()],
+                        },
+                    },
+                );
+                new_rules.insert(
+                    RuleType::LAMBDA_004,
+                    RuleTypeConfig {
+                        enabled: true,
+                        config_detail: RuleTypeConfigDetail::Threshold {
+                            threshold: ThresholdValue::Int(0),
+                        },
+                    },
+                );
+                new_rules.insert(
+                    RuleType::LAMBDA_005,
+                    RuleTypeConfig {
+                        enabled: true,
+                        config_detail: RuleTypeConfigDetail::Value {
+                            value: "INFO".to_string(),
+                        },
+                    },
+                );
                 new_rules.insert(RuleType::LAMBDA_006, enable(true));
-                new_rules.insert(RuleType::LAMBDA_007, RuleTypeConfig {
-                     enabled: true,
-                     config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Float(0.1) },
-                });
+                new_rules.insert(
+                    RuleType::LAMBDA_007,
+                    RuleTypeConfig {
+                        enabled: true,
+                        config_detail: RuleTypeConfigDetail::Threshold {
+                            threshold: ThresholdValue::Float(0.1),
+                        },
+                    },
+                );
                 new_rules.insert(RuleType::LAMBDA_008, enable(true));
                 new_rules.insert(RuleType::LAMBDA_009, enable(true));
-                new_rules.insert(RuleType::CW_001, RuleTypeConfig {
-                     enabled: true,
-                     config_detail: RuleTypeConfigDetail::Threshold { threshold: ThresholdValue::Int(14) },
-                });
+                new_rules.insert(
+                    RuleType::CW_001,
+                    RuleTypeConfig {
+                        enabled: true,
+                        config_detail: RuleTypeConfigDetail::Threshold {
+                            threshold: ThresholdValue::Int(14),
+                        },
+                    },
+                );
                 new_rules.insert(RuleType::CW_002, enable(true));
                 new_rules.insert(RuleType::CW_003, enable(true));
             }
@@ -274,7 +318,6 @@ impl RuleConfig {
         }
     }
 }
-
 
 impl Default for RuleConfig {
     fn default() -> Self {

--- a/src/rules/aws/lambda.rs
+++ b/src/rules/aws/lambda.rs
@@ -290,3 +290,153 @@ pub fn check_lambda_powertools_environment_variables<L: LineMarker>(
         }
     }
 }
+
+
+
+// LAMBDA-008: Check for VPC Gateway Endpoints
+pub fn check_lambda_vpc_gateway_endpoints<L: LineMarker>(
+    cloudformation: &CloudFormation,
+    error_reporter: &mut ErrorReporter,
+    line_marker: &L,
+) {
+    if let Some(resources) = &cloudformation.resources {
+        // First check if there are any Lambdas in a VPC
+        let mut vpc_lambda_found = false;
+        let mut violation_candidates = Vec::new();
+
+        for (key, resource) in resources {
+            if let AWSResourceType::LambdaFunction | AWSResourceType::LambdaServerlessFunction =
+                &resource.type_
+            {
+                if let Some(properties) = &resource.properties {
+                     if properties.contains_key("VpcConfig") {
+                        vpc_lambda_found = true;
+                        violation_candidates.push(key);
+                     }
+                }
+            }
+        }
+
+        if !vpc_lambda_found {
+            return;
+        }
+
+        // Now check if there are any Gateway Endpoints for S3 or DynamoDB
+        let mut endpoints_found = false;
+        for resource in resources.values() {
+             if let AWSResourceType::EC2VPCEndpoint = &resource.type_ {
+                 if let Some(properties) = &resource.properties {
+                     let service_name = properties
+                        .get("ServiceName")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                     
+                     let type_ = properties
+                        .get("VpcEndpointType")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("Gateway"); 
+
+                     if (service_name.contains("s3") || service_name.contains("dynamodb")) 
+                        && type_ == "Gateway" {
+                         endpoints_found = true;
+                         break;
+                     }
+                 }
+             }
+        }
+
+        if !endpoints_found {
+            // Updated to be a warning / acknowledgement of cross-stack resources
+            for key in violation_candidates {
+                error_reporter.add_error(
+                    Box::new(LambdaViolation::NoVPCGatewayEndpoint),
+                    key,
+                    line_marker
+                        .get_resource_span(vec![key, "Properties", "VpcConfig"])
+                        .copied(),
+                );
+            }
+        }
+    }
+}
+
+// LAMBDA-009: Check for Static Provisioned Concurrency without AutoScaling
+pub fn check_lambda_provisioned_concurrency_autoscaling<L: LineMarker>(
+    cloudformation: &CloudFormation,
+    error_reporter: &mut ErrorReporter,
+    line_marker: &L,
+) {
+     if let Some(resources) = &cloudformation.resources {
+        // Find Lambdas/Aliases with ProvisionedConcurrency > 0
+        let mut static_provisioning = Vec::new();
+
+        for (key, resource) in resources {
+             if let AWSResourceType::LambdaFunction | AWSResourceType::LambdaServerlessFunction =
+                &resource.type_
+             {
+                 if let Some(properties) = &resource.properties {
+                     if let Some(conf) = properties.get("ProvisionedConcurrencyConfig") {
+                         if let Some(val) = conf.get("ProvisionedConcurrentExecutions") {
+                             if val.as_u64().unwrap_or(0) > 0 {
+                                 static_provisioning.push(key);
+                             }
+                         }
+                     }
+                 }
+             }
+        }
+
+        // Find ScalableTargets for Lambda ProvisionedConcurrency
+        let mut scaled_resource_ids = Vec::new();
+        for resource in resources.values() {
+             if let AWSResourceType::ApplicationAutoScalingScalableTarget = &resource.type_ {
+                 if let Some(properties) = &resource.properties {
+                     let dimension = properties
+                        .get("ScalableDimension")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                     
+                     if dimension == "lambda:function:ProvisionedConcurrency" {
+                         if let Some(resource_id) = properties.get("ResourceId") {
+                             match resource_id {
+                                 serde_yaml::Value::String(s) => {
+                                     scaled_resource_ids.push(s.clone());
+                                 }
+                                 serde_yaml::Value::Tagged(tagged) => {
+                                     if tagged.tag.to_string() == "!Sub" {
+                                          if let serde_yaml::Value::String(s) = &tagged.value {
+                                              scaled_resource_ids.push(s.clone());
+                                          } else if let serde_yaml::Value::Sequence(seq) = &tagged.value {
+                                              if let Some(serde_yaml::Value::String(s)) = seq.first() {
+                                                  scaled_resource_ids.push(s.clone());
+                                              }
+                                          }
+                                     }
+                                 }
+                                 _ => {}
+                             }
+                         }
+                     }
+                 }
+             }
+        }
+
+        for key in static_provisioning {
+            // Check if the Lambda's Logical ID (key) is referenced in any ScalableTarget's ResourceId.
+            // This handles:
+            // - !Sub "function:${MyLambda}:provisioned" (contains "MyLambda")
+            // - "function:MyLambda:provisioned" (contains "MyLambda")
+            let is_scaled = scaled_resource_ids.iter().any(|rid| rid.contains(key));
+
+            if !is_scaled {
+                 error_reporter.add_error(
+                    Box::new(LambdaViolation::StaticProvisionedConcurrencyWithoutAutoScaling),
+                    key,
+                    line_marker
+                        .get_resource_span(vec![key, "Properties", "ProvisionedConcurrencyConfig"])
+                        .copied(),
+                );
+            }
+        }
+    }
+}

--- a/src/rules/aws/lambda.rs
+++ b/src/rules/aws/lambda.rs
@@ -402,7 +402,7 @@ pub fn check_lambda_provisioned_concurrency_autoscaling<L: LineMarker>(
                                     scaled_resource_ids.push(s.clone());
                                 }
                                 serde_yaml::Value::Tagged(tagged) => {
-                                    if tagged.tag.to_string() == "!Sub" {
+                                    if tagged.tag == "!Sub" {
                                         if let serde_yaml::Value::String(s) = &tagged.value {
                                             scaled_resource_ids.push(s.clone());
                                         } else if let serde_yaml::Value::Sequence(seq) =

--- a/src/rules/aws/lambda.rs
+++ b/src/rules/aws/lambda.rs
@@ -291,8 +291,6 @@ pub fn check_lambda_powertools_environment_variables<L: LineMarker>(
     }
 }
 
-
-
 // LAMBDA-008: Check for VPC Gateway Endpoints
 pub fn check_lambda_vpc_gateway_endpoints<L: LineMarker>(
     cloudformation: &CloudFormation,
@@ -309,10 +307,10 @@ pub fn check_lambda_vpc_gateway_endpoints<L: LineMarker>(
                 &resource.type_
             {
                 if let Some(properties) = &resource.properties {
-                     if properties.contains_key("VpcConfig") {
+                    if properties.contains_key("VpcConfig") {
                         vpc_lambda_found = true;
                         violation_candidates.push(key);
-                     }
+                    }
                 }
             }
         }
@@ -324,25 +322,26 @@ pub fn check_lambda_vpc_gateway_endpoints<L: LineMarker>(
         // Now check if there are any Gateway Endpoints for S3 or DynamoDB
         let mut endpoints_found = false;
         for resource in resources.values() {
-             if let AWSResourceType::EC2VPCEndpoint = &resource.type_ {
-                 if let Some(properties) = &resource.properties {
-                     let service_name = properties
+            if let AWSResourceType::EC2VPCEndpoint = &resource.type_ {
+                if let Some(properties) = &resource.properties {
+                    let service_name = properties
                         .get("ServiceName")
                         .and_then(|v| v.as_str())
                         .unwrap_or("");
-                     
-                     let type_ = properties
+
+                    let type_ = properties
                         .get("VpcEndpointType")
                         .and_then(|v| v.as_str())
-                        .unwrap_or("Gateway"); 
+                        .unwrap_or("Gateway");
 
-                     if (service_name.contains("s3") || service_name.contains("dynamodb")) 
-                        && type_ == "Gateway" {
-                         endpoints_found = true;
-                         break;
-                     }
-                 }
-             }
+                    if (service_name.contains("s3") || service_name.contains("dynamodb"))
+                        && type_ == "Gateway"
+                    {
+                        endpoints_found = true;
+                        break;
+                    }
+                }
+            }
         }
 
         if !endpoints_found {
@@ -366,59 +365,62 @@ pub fn check_lambda_provisioned_concurrency_autoscaling<L: LineMarker>(
     error_reporter: &mut ErrorReporter,
     line_marker: &L,
 ) {
-     if let Some(resources) = &cloudformation.resources {
+    if let Some(resources) = &cloudformation.resources {
         // Find Lambdas/Aliases with ProvisionedConcurrency > 0
         let mut static_provisioning = Vec::new();
 
         for (key, resource) in resources {
-             if let AWSResourceType::LambdaFunction | AWSResourceType::LambdaServerlessFunction =
+            if let AWSResourceType::LambdaFunction | AWSResourceType::LambdaServerlessFunction =
                 &resource.type_
-             {
-                 if let Some(properties) = &resource.properties {
-                     if let Some(conf) = properties.get("ProvisionedConcurrencyConfig") {
-                         if let Some(val) = conf.get("ProvisionedConcurrentExecutions") {
-                             if val.as_u64().unwrap_or(0) > 0 {
-                                 static_provisioning.push(key);
-                             }
-                         }
-                     }
-                 }
-             }
+            {
+                if let Some(properties) = &resource.properties {
+                    if let Some(conf) = properties.get("ProvisionedConcurrencyConfig") {
+                        if let Some(val) = conf.get("ProvisionedConcurrentExecutions") {
+                            if val.as_u64().unwrap_or(0) > 0 {
+                                static_provisioning.push(key);
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         // Find ScalableTargets for Lambda ProvisionedConcurrency
         let mut scaled_resource_ids = Vec::new();
         for resource in resources.values() {
-             if let AWSResourceType::ApplicationAutoScalingScalableTarget = &resource.type_ {
-                 if let Some(properties) = &resource.properties {
-                     let dimension = properties
+            if let AWSResourceType::ApplicationAutoScalingScalableTarget = &resource.type_ {
+                if let Some(properties) = &resource.properties {
+                    let dimension = properties
                         .get("ScalableDimension")
                         .and_then(|v| v.as_str())
                         .unwrap_or("");
-                     
-                     if dimension == "lambda:function:ProvisionedConcurrency" {
-                         if let Some(resource_id) = properties.get("ResourceId") {
-                             match resource_id {
-                                 serde_yaml::Value::String(s) => {
-                                     scaled_resource_ids.push(s.clone());
-                                 }
-                                 serde_yaml::Value::Tagged(tagged) => {
-                                     if tagged.tag.to_string() == "!Sub" {
-                                          if let serde_yaml::Value::String(s) = &tagged.value {
-                                              scaled_resource_ids.push(s.clone());
-                                          } else if let serde_yaml::Value::Sequence(seq) = &tagged.value {
-                                              if let Some(serde_yaml::Value::String(s)) = seq.first() {
-                                                  scaled_resource_ids.push(s.clone());
-                                              }
-                                          }
-                                     }
-                                 }
-                                 _ => {}
-                             }
-                         }
-                     }
-                 }
-             }
+
+                    if dimension == "lambda:function:ProvisionedConcurrency" {
+                        if let Some(resource_id) = properties.get("ResourceId") {
+                            match resource_id {
+                                serde_yaml::Value::String(s) => {
+                                    scaled_resource_ids.push(s.clone());
+                                }
+                                serde_yaml::Value::Tagged(tagged) => {
+                                    if tagged.tag.to_string() == "!Sub" {
+                                        if let serde_yaml::Value::String(s) = &tagged.value {
+                                            scaled_resource_ids.push(s.clone());
+                                        } else if let serde_yaml::Value::Sequence(seq) =
+                                            &tagged.value
+                                        {
+                                            if let Some(serde_yaml::Value::String(s)) = seq.first()
+                                            {
+                                                scaled_resource_ids.push(s.clone());
+                                            }
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         for key in static_provisioning {
@@ -429,7 +431,7 @@ pub fn check_lambda_provisioned_concurrency_autoscaling<L: LineMarker>(
             let is_scaled = scaled_resource_ids.iter().any(|rid| rid.contains(key));
 
             if !is_scaled {
-                 error_reporter.add_error(
+                error_reporter.add_error(
                     Box::new(LambdaViolation::StaticProvisionedConcurrencyWithoutAutoScaling),
                     key,
                     line_marker

--- a/src/rules/violations.rs
+++ b/src/rules/violations.rs
@@ -15,6 +15,9 @@ pub enum LambdaViolation {
     PowertoolsLogLevel,
     PowertoolsLoggerLogEvent,
     PowertoolsLoggerSampleRate,
+
+    NoVPCGatewayEndpoint,
+    StaticProvisionedConcurrencyWithoutAutoScaling,
 }
 
 impl Violation for LambdaViolation {
@@ -51,6 +54,15 @@ impl Violation for LambdaViolation {
                 "Set the POWERTOOLS_LOGGER_SAMPLE_RATE environment variable to a value between 0 and 1 \
                 to sample logs and reduce logging costs when using AWS Lambda Powertools.".to_string()
             }
+
+            LambdaViolation::NoVPCGatewayEndpoint => {
+                "Lambda function is in a VPC but no compatible Gateway Endpoint (S3/DynamoDB) was found in THIS template. \
+                Verify that S3/DynamoDB Gateway Endpoints are configured (possibly in another stack) to avoid NAT Gateway charges.".to_string()
+            }
+            LambdaViolation::StaticProvisionedConcurrencyWithoutAutoScaling => {
+                "Static Provisioned Concurrency detected. Consider using Application Auto Scaling \
+                to optimize costs by scheduling concurrency or scaling based on utilization.".to_string()
+            }
         }
     }
 
@@ -63,6 +75,9 @@ impl Violation for LambdaViolation {
             LambdaViolation::PowertoolsLogLevel => "LAMBDA-005".to_string(),
             LambdaViolation::PowertoolsLoggerLogEvent => "LAMBDA-006".to_string(),
             LambdaViolation::PowertoolsLoggerSampleRate => "LAMBDA-007".to_string(),
+
+            LambdaViolation::NoVPCGatewayEndpoint => "LAMBDA-008".to_string(),
+            LambdaViolation::StaticProvisionedConcurrencyWithoutAutoScaling => "LAMBDA-009".to_string(),
         }
     }
 }

--- a/src/rules/violations.rs
+++ b/src/rules/violations.rs
@@ -77,7 +77,9 @@ impl Violation for LambdaViolation {
             LambdaViolation::PowertoolsLoggerSampleRate => "LAMBDA-007".to_string(),
 
             LambdaViolation::NoVPCGatewayEndpoint => "LAMBDA-008".to_string(),
-            LambdaViolation::StaticProvisionedConcurrencyWithoutAutoScaling => "LAMBDA-009".to_string(),
+            LambdaViolation::StaticProvisionedConcurrencyWithoutAutoScaling => {
+                "LAMBDA-009".to_string()
+            }
         }
     }
 }


### PR DESCRIPTION
1. LAMBDA-008 - Ensure Lambda functions in a VPC have compatible Gateway Endpoints (S3/DynamoDB) to avoid expensive NAT Gateway data processing charges.
2. LAMBDA-009 - Detect Static Provisioned Concurrency without AutoScaling. Suggests using Application Auto Scaling to optimize costs during low-traffic periods.